### PR TITLE
[유병규-1주차 알고리즘 스터디]

### DIFF
--- a/유병규_1주차/BOJ_14716.java
+++ b/유병규_1주차/BOJ_14716.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static int[][] map;
+    private static boolean[][] visited;
+    private static int count=0;
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int m = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+
+        map = new int[m][n];
+
+        for(int i=0; i<m; i++) {
+            st = new StringTokenizer(br.readLine());
+            for(int j=0; j<n; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        visited = new boolean[m][n];
+
+        for(int i=0; i<m; i++) {
+            for(int j=0; j<n; j++) {
+                if(map[i][j] == 0 || visited[i][j]) continue;
+                count++;
+                dfs(m, n, i, j);
+            }
+        }
+
+        System.out.println(count);
+    }
+
+    private static void dfs(int m, int n, int i, int j) {
+        if(i<0 || i>=m || j<0 || j>=n) {
+            return;
+        }
+
+        if(visited[i][j]) return;
+        if(map[i][j] == 0) return;
+        visited[i][j] = true;
+        int[][] d = {{-1,0}, {-1,1}, {0,1}, {1,1}, {1,0}, {1,-1}, {0,-1}, {-1,-1}};
+        for(int x=0; x<d.length; x++) {
+            int nx = i+d[x][0];
+            int ny = j+d[x][1];
+            dfs(m, n, nx, ny);
+        }
+    }
+
+}

--- a/유병규_1주차/BOJ_17074.java
+++ b/유병규_1주차/BOJ_17074.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[] numbers = Arrays.stream(br.readLine().split(" "))
+                .mapToInt(Integer::parseInt)
+                .toArray();
+
+        int result = 0;
+        boolean isSort = true;
+        for(int i=0; i<n-1; i++) {
+            if(numbers[i] > numbers[i+1]) {
+                if(!isSort) {
+                    System.out.println(0);
+                    return;
+                }
+                if(i==0) {
+                    result++;
+                }
+                if(i-1>=0 && i+1<n && numbers[i-1] <= numbers[i+1]) {
+                    result++;
+                }
+                if(i+2>=n || numbers[i] <= numbers[i+2]) {
+                    result++;
+                }
+                isSort = false;
+            }
+        }
+        if(isSort && result == 0) {
+            result = n;
+        }
+
+        System.out.println(result);
+    }
+
+}

--- a/유병규_1주차/BOJ_17089.java
+++ b/유병규_1주차/BOJ_17089.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    private static int[][] graph;
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        graph = new int[n+1][n+1];
+
+        for(int i=0; i<m; i++) {
+            int[] edge = Arrays.stream(br.readLine().split(" "))
+                    .mapToInt(Integer::parseInt)
+                    .toArray();
+            graph[edge[0]][edge[1]] = 1;
+            graph[edge[0]][0]++;
+            graph[edge[1]][edge[0]] = 1;
+            graph[edge[1]][0]++;
+        }
+        int min = Integer.MAX_VALUE;
+        for(int i=1; i<=n; i++) {
+            for(int j=i+1; j<=n; j++) {
+                if(graph[i][j] == 0) continue;
+                for(int k=j+1; k<=n; k++) {
+                    if(graph[j][k] == 1 && graph[k][i] == 1) {
+                        int total = graph[i][0]+graph[j][0]+graph[k][0] - 6;
+                        min = Math.min(min, total);
+                    }
+                }
+            }
+        }
+
+        if(min == Integer.MAX_VALUE) System.out.println(-1);
+        else System.out.println(min);
+    }
+
+}

--- a/유병규_1주차/BOJ_17225.java
+++ b/유병규_1주차/BOJ_17225.java
@@ -1,0 +1,78 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+
+public class Main {
+    private static PriorityQueue<int[]> workList;
+
+    private static List<Integer> sangmin = new ArrayList<>();
+    private static List<Integer> jisoo = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String[] inputs = br.readLine().split(" ");
+        int a = Integer.parseInt(inputs[0]);
+        int b = Integer.parseInt(inputs[1]);
+        int n = Integer.parseInt(inputs[2]);
+
+        workList = new PriorityQueue<>((o1, o2) -> {
+            if(o1[1] < o2[1]) return -1;
+            if(o1[1] > o2[1]) return 1;
+            if(o1[0] < o2[0]) return -1;
+            return 1;
+        });
+
+        int sangminTime=0, jisooTime=0;
+        for(int i=0; i<n; i++) {
+            String[] line = br.readLine().split(" ");
+            int time = Integer.parseInt(line[0]);
+            String color = line[1];
+            int count = Integer.parseInt(line[2]);
+
+            if(color.equals("B")) {
+                time = sangminTime < time ? time : sangminTime;
+                for(int j=0; j<count; j++) {
+                    sangminTime = time+j*a;
+                    int[] work = {0, time+j*a};
+                    workList.offer(work);
+                }
+                sangminTime += a;
+                continue;
+            }
+            time = jisooTime < time ? time : jisooTime;
+            for(int j=0; j<count; j++) {
+                jisooTime = time+j*b;
+                int[] work = {1, time+j*b};
+                workList.offer(work);
+            }
+            jisooTime += b;
+        }
+
+        int boxNum = 1;
+        while(!workList.isEmpty()) {
+            int[] work = workList.poll();
+
+            if(work[0] == 0) {
+                sangmin.add(boxNum++);
+            }
+            else {
+                jisoo.add(boxNum++);
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(sangmin.size()).append("\n");
+        for(int num : sangmin) {
+            sb.append(num).append(" ");
+        }
+        sb.append("\n").append(jisoo.size()).append("\n");
+        for(int num : jisoo) {
+            sb.append(num).append(" ");
+        }
+
+        System.out.println(sb.toString().trim());
+    }
+}

--- a/유병규_1주차/BOJ_2806.java
+++ b/유병규_1주차/BOJ_2806.java
@@ -1,0 +1,27 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        String dna = br.readLine();
+
+        int[][] dp = new int[n+1][2];
+
+        for(int i=1; i<=n; i++) {
+            if(dna.charAt(i-1) == 'A') {
+                dp[i][0] = Math.min(dp[i-1][0], dp[i-1][1]+1);
+                dp[i][1] = Math.min(dp[i-1][0]+1, dp[i-1][1]+1);
+            }
+            else {
+                dp[i][0] = Math.min(dp[i-1][0]+1, dp[i-1][1]+1);
+                dp[i][1] = Math.min(dp[i-1][0]+1, dp[i-1][1]);
+            }
+        }
+
+        System.out.println(dp[n][0]);
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 1주차 [유병규] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **세훈이의 선물가게**
  - [x] **세 친구**  
  - [x] **정렬**
  - [x] **현수막**  
  - [x] **DNA**  
  - [ ] **열쇠**

---

## 💡 풀이 방법
### 문제 1: 세훈이의 선물가게

**문제 난이도**
- 실버 1


**문제 유형**
- 구현, 정렬, 시뮬레이션


 **접근 방식 및 풀이**
- *Priority Queue, ArrayList*
- 상민과 지수가 포장할 선물의 번호(순서)들은 상민과 지수가 포장을 시작하는 시간에 따라 정해집니다. 포장을 시작하는 시간이 빠를수록 포장할 선물을 먼저 배정 받기 때문에, 상민과 지수가 선물을 포장하는 시간을 저장하는 우선순위 큐를 사용하였습니다. 
- 우선순위 큐에는 길이 2의 int 배열을 저장하며, int 배열에는 [(포장하는 사람), (포장이 시작되는 시간)]을 저장합니다. '포장하는 사람'에는 상민이면 '0', 지수면 '1'을 저장하며, 만약 '포장이 시작되는 시간'이 같다면 상민이 선물을 먼저 배정받기 때문에 우선순위 큐의 정렬 기준을 위 내용에 맞게 수정하였습니다. 마지막으로 주문에 따라 우선순위 큐에 정보를 모두 담으면 다시 순서대로 꺼내면서 상민과 지수가 각각 포장하는 선물의 번호를 체크하여 결과를 출력하였습니다.
   
---

### 문제 2: 세 친구

**문제 난이도**
- 골드 5


**문제 유형**
- 그래프 이론, 브루트포스 알고리즘


 **접근 방식 및 풀이**
- *int[][]*
- 처음에는 백트래킹을 사용하여 시도하였지만 시간초과+메모리초과로 인해 풀이방법을 수정하였습니다.
- 친구 정보를 int[][]에 저장하였으며, [(사람 번호), 0]에는 총 친구의 수, [(사람 번호), (사람 번호)]에는 친구이면 1, 아니면 0을 저장하였습니다. 해당 그래프를 순회하며 먼저 A사람 배열에서 친구인 B사람을 찾으면, B사람 배열에서 A와 B 모두와 친구인 C 사람을 찾아 총 친구 수를 계산하는 방식으로 구현하였습니다. 모든 배열을 순회한 후 총 친구 수의 최솟값을 출력하였습니다.


---

### 문제 3: 정렬
 
**문제 난이도**
- 실버 1


**문제 유형**
- 다이나믹 프로그래밍, 많은 조건 분기


 **접근 방식 및 풀이**
- 먼저, 배열에서 하나를 제거했을 때 비내림차순으로 정렬이 되어있어야 하기 때문에, 만약 2개 이상 정렬이 안 되어 있다면 끝내도록 구현하였습니다. 그리고 제거할 대상 기준 양 옆이 정렬이 되어 있는 경우, 

---

### 문제 4: 현수막
 
**문제 난이도**
- 실버 1


**문제 유형**
- 그래프 이론, 그래프 탐색, DFS, BFS


 **접근 방식 및 풀이**
- DFS로 접근하였고, 이어진 글자의 경우 같은 영역으로 인지하며 개수를 세어갔습니다.

---

### 문제 5: DNA 발견

**문제 난이도**
- 골드 4


**문제 유형**
- 다이나믹 프로그래밍


 **접근 방식 및 풀이**
- 현재 글자 기준 앞 문자열이 모두 A인 경우와 모두 B인 경우로 나누어 접근하였습니다. DP에는 해당 글자 위치까지 모두 A로 만드는 최소 횟수, B로 만드는 최소 횟수를 저장하며, 현재 추가되는 글자가 A인 경우, B인 경우로 나누오 문제를 해결하였습니다.
