### PR TITLE
Ybg6539/week 3

### DIFF
--- a/유병규_3주차/[BOJ-15558] 점프 게임.java
+++ b/유병규_3주차/[BOJ-15558] 점프 게임.java
@@ -1,0 +1,61 @@
+import java.io.*;
+import java.util.*;
+
+/*
+ * 1에서 시작, n넘어가면 성공(성공하면 1, 아니면 0 출력)
+ * 0이 위험, 1이 안전
+ * 1. 앞으로 이동
+ * 2. 뒤로 이동
+ * 3. 옆 줄의 k칸 앞으로 이동
+ * */
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+
+        int[][] line = new int[2][n];
+        String input = br.readLine();
+        for(int i=0; i<n; i++) {
+            line[0][i] = input.charAt(i) - '0';
+        }
+        input = br.readLine();
+        for(int i=0; i<n; i++) {
+            line[1][i] = input.charAt(i) - '0';
+        }
+
+        //bfs
+        boolean[][] visited = new boolean[2][n];
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[] {0,0,0});
+        int[] move = {1, -1, k};
+
+        while(!queue.isEmpty()) {
+            int[] current = queue.poll();
+            for(int i=0; i<3; i++) {
+                int ny = current[1] + move[i];
+                int nx = current[0];
+                int time = current[2];
+
+                if(i == 2) {
+                    nx = 1 - current[0];
+                }
+
+                if(ny>=n) {
+                    System.out.println(1);
+                    return;
+                }
+
+                if(ny <= time) continue;
+                if(visited[nx][ny]) continue;
+                if(line[nx][ny] == 0) continue;
+
+                visited[nx][ny] = true;
+                queue.offer(new int[] {nx, ny, time+1});
+            }
+        }
+        System.out.println(0);
+    }
+
+}

--- a/유병규_3주차/[BOJ-1953] 팀배분.java
+++ b/유병규_3주차/[BOJ-1953] 팀배분.java
@@ -1,0 +1,57 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static int[][] graph;
+    private static int n;
+    private static int[] team;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        graph = new int[n+1][n+1];
+        for(int i=1; i<=n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int count = Integer.parseInt(st.nextToken());
+            for(int j=1; j<=count; j++) {
+                graph[i][Integer.parseInt(st.nextToken())] = 1;
+            }
+        }
+
+        team = new int[n+1];
+        team[1] = 1;
+        dfs(1, 1);
+
+        int count = 0;
+        StringBuilder team1 = new StringBuilder();
+        StringBuilder team2 = new StringBuilder();
+        for(int i=1; i<=n; i++) {
+            if(team[i] == 1) {
+                count++;
+                team1.append(i+" ");
+                continue;
+            }
+            team2.append(i+" ");
+        }
+
+        System.out.println(count+"\n"+team1.toString().trim()+"\n"
+                +(n-count)+"\n"+team2.toString().trim());
+    }
+
+    private static void dfs(int index, int teamColor) {
+        if(index > n) {
+            return;
+        }
+        for(int i=1; i<=n; i++) {
+            if(graph[index][i] == 0) continue;
+            if(team[i] == teamColor) break;
+
+            team[i] = -teamColor;
+        }
+        if(index+1 > n) return;
+        if(team[index+1] == 0) team[index+1] = teamColor;
+        dfs(index+1, team[index+1]);
+    }
+
+}

--- a/유병규_3주차/[BOJ-23843] 콘센트.java
+++ b/유병규_3주차/[BOJ-23843] 콘센트.java
@@ -1,0 +1,47 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        // n = 전자기기 개수, m = 콘센트 개수
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        // times = 전자기기별 충전시간
+        int[] times = new int[n];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++) {
+            times[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // times 오름차순 정렬(int[]은 오름차순만 가능)
+        Arrays.sort(times);
+
+        // 우선순위큐에 콘센트 개수만큼 0(=초기값) 삽입
+        PriorityQueue<Integer> priorityQueue = new PriorityQueue<>();
+        for(int i=0; i<m; i++) {
+            priorityQueue.offer(0);
+        }
+
+        // times를 오름차순으로 정렬했기에 가장 큰 값부터 넣기 위해 뒤에서 부터 반복
+        for(int i=n-1; i>=0; i--) {
+            int number = priorityQueue.poll();
+            priorityQueue.offer(number+times[i]);
+        }
+
+        // 제일 큰 값을 얻기 위해 1개 빼고 전부 제거
+        while(priorityQueue.size() > 1) {
+            priorityQueue.poll();
+        }
+
+        // 마지막 남은 거(제일 큰 값) 출력
+        System.out.println(priorityQueue.poll());
+    }
+}

--- a/유병규_3주차/[BOJ-4577] 소코반.java
+++ b/유병규_3주차/[BOJ-4577] 소코반.java
@@ -1,0 +1,152 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    private static final String DONE = "complete";
+    private static final String NONDONE = "incomplete";
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int index = 1;
+        while(true) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int r = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+
+            if(r == 0 && c==0) break;
+
+            char[][] map = new char[r][c];
+            int[] userPoint = new int[2];
+            int total = 0;
+            int successBox = 0;
+
+            for(int i=0; i<r; i++) {
+                String line = br.readLine();
+                for(int j=0; j<c; j++) {
+                    map[i][j] = line.charAt(j);
+                    if(map[i][j] == '+') total++;
+                    else if(map[i][j] == 'B') {
+                        total++;
+                        successBox++;
+                    }
+                    else if(map[i][j] == 'W') {
+                        total++;
+                        userPoint[0] = i;
+                        userPoint[1] = j;
+                    }
+                    else if(map[i][j] == 'w') {
+                        userPoint[0] = i;
+                        userPoint[1] = j;
+                    }
+                }
+            }
+
+            String inputKeys = br.readLine();
+
+            boolean isSuccess = false;
+            for(char key : inputKeys.toCharArray()) {
+                if(successBox == total) {
+                    isSuccess = true;
+                    break;
+                }
+
+                successBox = move(r, c, map, userPoint, successBox, key);
+            }
+            if(successBox == total) {
+                isSuccess = true;
+            }
+
+            sb.append("Game "+index + ": ");
+
+            if(isSuccess) sb.append(DONE);
+            else sb.append(NONDONE);
+
+            sb.append("\n");
+            for(int i=0; i<r; i++) {
+                for(int j=0; j<c; j++) {
+                    sb.append(map[i][j]+"");
+                }
+                sb.append("\n");
+            }
+            index++;
+
+        }
+        System.out.println(sb.toString().trim());
+    }
+
+    private static int move(int r, int c, char[][] map, int[] userPoint, int successBox, char key) {
+        int[] d = parseKey(key);
+        int nx = userPoint[0] + d[0];
+        int ny = userPoint[1] + d[1];
+
+        if(nx<0 || nx>=r || ny<0 || ny>=c || map[nx][ny] == '#')
+            return successBox;
+
+        if(map[nx][ny] == '.') {
+            map[nx][ny] = 'w';
+
+            moveUser(map, userPoint, nx, ny);
+            return successBox;
+        }
+
+        if(map[nx][ny] == '+') {
+            map[nx][ny] = 'W';
+
+            moveUser(map, userPoint, nx, ny);
+            return successBox;
+        }
+
+        // 1(userPoint) 2(nx, ny) 3(boxNx, boxNy)
+        int boxNx = nx + d[0];
+        int boxNy = ny + d[1];
+        if(boxNx<0 || boxNx>=r || boxNy<0 || boxNy>=c || map[boxNx][boxNy] == '#' || map[boxNx][boxNy] == 'b')
+            return successBox;
+
+        if(map[boxNx][boxNy] == '.') {
+            //3
+            map[boxNx][boxNy] = 'b';
+            //2
+            if(map[nx][ny] == 'B') {
+                map[nx][ny] = 'W';
+                successBox--;
+            }
+            else map[nx][ny] = 'w';
+            moveUser(map, userPoint, nx, ny);
+            return successBox;
+        }
+
+        if(map[boxNx][boxNy] == '+') {
+            //3
+            map[boxNx][boxNy] = 'B';
+            successBox++;
+            //2
+            if(map[nx][ny] == 'B') map[nx][ny] = 'W';
+            else map[nx][ny] = 'w';
+            //1
+            moveUser(map, userPoint, nx, ny);
+            return successBox;
+        }
+        return successBox;
+    }
+
+    private static void moveUser(char[][] map, int[] userPoint, int nx, int ny) {
+        if(map[userPoint[0]][userPoint[1]] == 'W') {
+            map[userPoint[0]][userPoint[1]] = '+';
+        }
+        else map[userPoint[0]][userPoint[1]] = '.';
+
+        userPoint[0] = nx;
+        userPoint[1] = ny;
+    }
+
+    private static int[] parseKey(char key) {
+        if(key == 'U') return new int[] {-1, 0};
+        if(key == 'D') return new int[] {1, 0};
+        if(key == 'L') return new int[] {0, -1};
+        return new int[] {0, 1};
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 3주차 [유병규] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **콘센트**
  - [ ] **소코반**  
  - [x] **점프 게임**
  - [ ] **팀배분**  
  - [ ] **조 짜기**  

---
  - [ ] **고기잡이**  
  - [ ] **모자이크**  

---
## 💡 풀이 방법
### 문제 1: 콘센트

**문제 난이도**
- 골드 5


**문제 유형**
- 자료 구조, 그리디 알고리즘, 정렬, 우선순위 큐


 **접근 방식 및 풀이**
- 처음 봤을 때 두 가지 방법을 생각했습니다. 충전 시간이 가장 작은 순과 가장 긴 순, 두 가지 방법을 생각했습니다.
- 충전 시간이 가장 작은 순의 경우 충전해야 할 다음 전자기기로 넘어갈 수록 총 시간이 +만 되는 것을 확인했습니다.
- 반면 가장 긴 순의 경우 충전해야 할 다음 전자기기로 넘어갈수록 총 시간이 +되지 않고 더 긴 시간 충전되는 동안 시간이 겹쳐 상쇄되는 것을 확인했습니다.
- 그래서 충전 시간이 가장 긴 전자기기 순으로 충전을 진행해야 하는 것을 확인했습니다.
- 직접 손으로 시뮬레이션을 해보면서 전자기기가 충전 중인 콘센트 중 가장 적은 시간 동안 충전된 콘센트에 다음 전자기기를 충전해야 하는 규칙을 발견했고 이를 구현하기 위해 우선순위 큐를 사용하였습니다.
   
---


### 문제 2: 소코반

**문제 난이도**
- 골드 3


**문제 유형**
- 구현, 시뮬레이션


 **접근 방식 및 풀이**
- **구현은 해봤지만, 왜 틀린 지 찾지 못해 아직 해결하지 못했습니다.(해결하면 다시 수정하겠습니다...ㅠㅠ)**
- 문제 내용을 그대로 구현하였습니다.
- 캐릭터가 이동할 때 + 위치를 주의하여 코드를 구현하였습니다.
   
---


### 문제 3: 점프 게임

**문제 난이도**
- 골드 5


**문제 유형**
- 그래프 이론, 그래프 탐색, BFS


 **접근 방식 및 풀이**
- 매 시간마다 선택해야 하는 경우의 수가 3개가 있고, 하나의 경우를 깊게 파악하는 것보다 하나씩 경우의 수를 따져보는 것이 더 효율적일 것이라 생각해 BFS를 선택하였습니다.
- 라인을 저장하는 2차원 배열을 만들고 각 경우를 저장하는 queue를 만들어 BFS를 수행하여 해결할 수 있었습니다.
   
---


### 문제 4: 팀배분

**문제 난이도**
- 골드 4


**문제 유형**
- 그래프 이론, 그래프 탐색, BFS, DFS, 이분 그래프


 **접근 방식 및 풀이**
- **이 문제도 구현은 해봤지만, 왜 틀린 지 찾지 못해 아직 해결하지 못했습니다.(해결하면 다시 수정하겠습니다...ㅠㅠ)**
- 먼저 사람의 관계를 저장하는 2차원 배열을 만들고 싫어하는 관계는 1로 표시했습니다.
- 그리고 각 사람의 팀 정보를 저장하는 1차원 배열을 만들어 청팀은 1, 백팀은 -1, 미정은 0으로 구분하였습니다.
- 각 노드(사람)가 있고 싫어하는 사람이 있을 경우(graph의 값이 1) 이를 연결된 노드라고 생각하였고, 연결된 인접한 노드끼리는 같은 팀을 하지 않도록 구현하면 된다고 생각하였습니다. 노드 탐색의 경우 BFS, DFS 둘 다 가능할 것이라 생각하여 평소에 좀 더 익숙한 DFS로 구현하였습니다.
- 각 노드를 시작으로 해당 노드와 연결되어 있는 노드는 다른 팀으로 구분하며 문제를 해결하였습니다. DFS를 구현하는데 기저조건을 설정하는 것이 다소 어려움이 있었습니다.
   
---


### 문제 5: 조짜기

**문제 난이도**
- 골드 5


**문제 유형**
- DP


 **접근 방식 및 풀이**
- 아직 문제를 해결하지 못했습니다. 해결하면 다시 수정하겠습니다.
   