### PR TITLE
Ybg6539/week 4

### DIFF
--- a/유병규_4주차/[BOJ-13325] 이진 트리.java
+++ b/유병규_4주차/[BOJ-13325] 이진 트리.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+
+        int[] tree = new int[(int)Math.pow(2, n+1)];
+        st = new StringTokenizer(br.readLine());
+        for(int i=2; i<tree.length; i++) {
+            tree[i] = Integer.parseInt(st.nextToken());
+        }
+
+        //find max
+        int maxValue = 0;
+        for(int i=(int) Math.pow(2, n); i<(int) Math.pow(2, n+1); i++) {
+            int sum = 0;
+            int current = i;
+            while(current > 0) {
+                sum += tree[current];
+                current /= 2;
+            }
+            maxValue = Math.max(maxValue, sum);
+        }
+
+        //setting
+        boolean[] visited = new boolean[tree.length];
+        visited[1] = true;
+        for(int i=1; i<=n; i++) {
+            int base = (int) Math.pow(2, i+1);
+            for(int j=(int) Math.pow(2, n); j<(int) Math.pow(2, n+1); j++) {
+                int childSum = 0;
+                int current = j;
+                while(current >= base) {
+                    childSum += tree[current];
+                    current /= 2;
+                }
+                int parentSum=0;
+                int parent = current/2;
+                while(parent > 0) {
+                    parentSum+= tree[parent];
+                    parent /= 2;
+                }
+                if(!visited[current]) {
+                    visited[current] = true;
+                    tree[current] = maxValue;
+                }
+                tree[current] = Math.min(tree[current], maxValue-(childSum+parentSum));
+            }
+        }
+
+        //total
+        int total=0;
+        for(int i=1; i<tree.length; i++) {
+            total += tree[i];
+        }
+        System.out.println(total);
+    }
+}

--- a/유병규_4주차/[BOJ-16498] 작은 벌점.java
+++ b/유병규_4주차/[BOJ-16498] 작은 벌점.java
@@ -1,0 +1,77 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        st = new StringTokenizer(br.readLine());
+
+        int a = Integer.parseInt(st.nextToken());
+        int b = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+
+        int[] nums1 = createSortedNums(a);
+        int[] nums2 = createSortedNums(b);
+        int[] nums3 = createSortedNums(c);
+
+        int minValue = Math.min(Math.min(a, b), c);
+
+        int result = 0;
+        if(minValue == a) result = findMin(nums1, nums2, nums3);
+        else if(minValue == b) result = findMin(nums2, nums1, nums3);
+        else result = findMin(nums3, nums1, nums2);
+
+        System.out.println(result);
+    }
+
+    private static int findMin(int[] base, int[] arr1, int[] arr2) {
+        int min = Integer.MAX_VALUE;
+
+        for(int i=0; i<base.length; i++) {
+            int num = base[i];
+            int[] nearNums1 = getNearNums(arr1, num);
+            int[] nearNums2 = getNearNums(arr2, num);
+
+            for(int num1 : nearNums1) {
+                for(int num2 : nearNums2) {
+                    min = Math.min(min, Math.abs(
+                            Math.max(Math.max(num, num1), num2)
+                                    - Math.min(Math.min(num, num1), num2)));
+                }
+            }
+        }
+        return min;
+    }
+
+    private static int[] getNearNums(int[] arr, int num) {
+        int left=0, right=arr.length-1, mid=0;
+
+        while(left < right) {
+            int nextMid = (right+left)/2;
+            if(nextMid == mid) break;
+            mid = nextMid;
+
+            if(arr[mid] == num) return new int[] {num};
+
+            if(arr[mid] > num) {
+                right = mid;
+                continue;
+            }
+            left = mid;
+        }
+
+        return new int[] {arr[left], arr[right]};
+    }
+
+    private static int[] createSortedNums(int length) throws IOException{
+        st = new StringTokenizer(br.readLine());
+        int[] nums = new int[length];
+        for(int i=0; i<length; i++) {
+            nums[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(nums);
+        return nums;
+    }
+}

--- a/유병규_4주차/[BOJ-30804] 과일 탕후루.java
+++ b/유병규_4주차/[BOJ-30804] 과일 탕후루.java
@@ -1,0 +1,34 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br  = new BufferedReader(new InputStreamReader(System.in));
+    private static StringTokenizer st;
+
+    public static void main(String[] args) throws IOException {
+        int n = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        int[] stick = new int[n];
+        for(int i=0; i<n; i++) {
+            stick[i] = Integer.parseInt(st.nextToken());
+        }
+
+        Map<Integer, Integer> map = new HashMap<>();
+        int left = 0;
+        int max = 0;
+        for(int right=0; right<n; right++) {
+            map.put(stick[right], map.getOrDefault(stick[right], 0) + 1);
+
+            while(map.size() >= 3) {
+                map.put(stick[left], map.get(stick[left])-1);
+                if(map.get(stick[left]) == 0) map.remove(stick[left]);
+                left++;
+            }
+
+            max = Math.max(max, right - left +1);
+        }
+
+        System.out.println(max);
+    }
+}

--- a/유병규_4주차/[BOJ-9252] LCS 2.java
+++ b/유병규_4주차/[BOJ-9252] LCS 2.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static StringBuilder sb =new StringBuilder();
+    private static char[] str1, str2;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        str1 = br.readLine().toCharArray();
+        str2 = br.readLine().toCharArray();
+
+        int length1 = str1.length;
+        int length2 = str2.length;
+
+        int[][] dp = new int[length1+1][length2+1];
+        for(int i=1; i<=length1; i++) {
+            for(int j=1; j<=length2; j++) {
+                if(str1[i-1] == str2[j-1]) {
+                    dp[i][j] = dp[i-1][j-1] + 1;
+                }
+                else {
+                    dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]);
+                }
+            }
+        }
+
+        getString(dp, length1, length2);
+        System.out.println(dp[length1][length2]);
+        if(dp[length1][length2] == 0) return;
+        System.out.println(sb.toString());
+    }
+
+    private static void getString(int[][] dp, int x, int y) {
+        Stack<Character> stack = new Stack<>();
+        while(x>0 && y>0) {
+            if(dp[x][y] == dp[x-1][y]) {
+                x--;
+                continue;
+            }
+            if(dp[x][y] == dp[x][y-1]) {
+                y--;
+                continue;
+            }
+            stack.push(str1[x-1]);
+            x--;
+            y--;
+        }
+
+        while(!stack.isEmpty()) {
+            sb.append(stack.pop()+"");
+        }
+    }
+}

--- a/유병규_4주차/[BOJ-9440] 숫자 더하기.java
+++ b/유병규_4주차/[BOJ-9440] 숫자 더하기.java
@@ -1,0 +1,70 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringBuilder sb = new StringBuilder();
+        while(true) {
+            //0 입력 시 종료
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int count = Integer.parseInt(st.nextToken());
+            if(count == 0) break;
+
+            //numbers 세팅 및 0 개수 세기
+            int zeroCount = 0;
+            int[] numbers = new int[count];
+            for(int i=0; i<count; i++) {
+                numbers[i] = Integer.parseInt(st.nextToken());
+                if(numbers[i] == 0) zeroCount++;
+            }
+
+            //숫자열 오름차순 정렬
+            Arrays.sort(numbers);
+
+            //만들어질 수 두 개
+            StringBuilder num1 = new StringBuilder();
+            StringBuilder num2 = new StringBuilder();
+
+            //만약 주어진 숫자열의 길이가 홀수이면서 0의 개수가 홀수인 경우, 0을 하나 제외
+            int start=0;
+            if(numbers.length%2!=0 && zeroCount%2!=0) {
+                start=1;
+            }
+
+            //num1과 num2에 각 숫자 배분
+            for(int i=start; i<numbers.length; i++) {
+                if(i%2==0)num1.append(numbers[i]);
+                else num2.append(numbers[i]);
+            }
+
+            //만약 0을 하나 제외했던 경우라면 만들어진 두 수(num1, num2) 중 더 작은 수 앞에 제거했던 0 추가
+            if(start == 1) {
+                if(Integer.parseInt(num1.toString()) > Integer.parseInt(num2.toString()))
+                    num2.insert(0, '0');
+                else num1.insert(0, '0');
+            }
+
+            //숫자가 0부터 시작한다면 0 다음으로 작은 숫자와 위치 변경하기
+            if(num1.charAt(0) == '0') swap(num1);
+            if(num2.charAt(0) == '0') swap(num2);
+
+            //두 수의 합 계산
+            int result = Integer.parseInt(num1.toString()) + Integer.parseInt(num2.toString());
+            sb.append(result).append("\n");
+        }
+
+        System.out.println(sb.toString().trim());
+    }
+
+    private static void swap(StringBuilder num) {
+        int index = 1;
+        while(num.charAt(index) == '0') {
+            index++;
+        }
+        num.setCharAt(0, num.charAt(index));
+        num.setCharAt(index, '0');
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 4주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **LCS 2**
- [x]  **숫자 더하기**
- [x]  **과일 탕후루**
- [x]  **작은 벌점**
- [x]  **이진 트리**

---

- [ ]  **출근 기록**
- [ ]  **죽음의 비**

---

## 💡 풀이 방법

### 문제 1: LCS 2

**문제 난이도**

- 골드 4

**문제 유형**

- DP, 문자열

**접근 방식 및 풀이**

- 처음에는 문자열 1번과 2번이 있을 때 1번의 문자를 하나씩 2번과 대조해보며 찾는 그리디 방식으로 구현하였습니다. 하지만 그리디 방식으로 구현할 경우 순차적으로 탐색하기 때문에 가능한 모든 경우를 고려하지 않아 LCS에 적합하지 않은 방법임을 알았습니다.
- LCS 해결법을 찾아보았고 DP로 푸는 문제임을 알았습니다. DP로 LCS의 값을 모두 채운 후 다시 DP를 역으로 추적하면서 글자를 알아내는 방식을 구현하였으며, 역으로 추적하기 때문에 Stack 자료구조를 사용하여 답을 구하였습니다.
- LCS의 DP 해결방법
    - 1번 문자열을 X, 2번 문자열을 Y, 1번 문자열의 i번째 문자는 Xi, 2번 문자열의 j번째 문자는 Yj라고 하자.
    - DP[i][j] = X의 Xi까지 문자열과 Y의 Yj까지 문자열의 LCS이다. 즉, X의 길이가 n, Y의 길이가 m일 때 X, Y의 LCS는 DP[n][m]이다.
    - X와 Y가 있을 때 X의 마지막 문자(Xn)을 제거하면 두 가지 경우가 생긴다.
        1. LCS에 포함되어 있던 문자여서 LCS의 길이가 1 줄어든다.
        2. LCS에 포함되지 않았던 문자여서 LCS의 길이가 유지된다.
    - 이를 적용하면 다음과 같다.
        - Xn == Ym : 마지막 문자를 LCS에 포함되는 문자로 간주하면 Xn-1, Ym-1의 LCS 길이 + 1과 같은 값을 가진다.
        - Xn ≠ Ym : LCS에 Xn이 포함될 수도 Ym이 포함될 수도 있다.
            1. Xn이 포함: Ym은 LCS에 영향을 주지 않으므로 Xn, Ym-1의 LCS와 동일한 값을 가진다.
            2. Ym이 포함: Xn은 LCS에 영향을 주지 않으므로 Xn-1, Ym의 LCS와 동일한 값을 가진다.
    - 위 내용 중 Xn == Ym인 문자가 LCS에 포함되는 문자이기 때문에 위 규칙에 따라서 DP값을 DP[n][m]부터 역추적하며 LCS 문자를 찾아내었습니다.

---

### 문제 2: 숫자 더하기

**문제 난이도**

- 실버 2

**문제 유형**

-그리디 알고리즘, 정렬

**접근 방식 및 풀이**

- 숫자 두 개를 만들어 두 수의 합이 최소가 되기 위해서는 다음과 같은 규칙을 생각했습니다.
    1. 두 수의 길이의 차이가 최대 1이어야 한다.
    2. 각 수의 가장 큰 자릿수의 수는 주어진 수의 가장 작은 수이어야 한다.
- 이 규칙을 적용하기 위해 주어진 숫자열을 정렬한 후 작은 숫자부터 번갈아가며 하나씩 숫자를 붙여서 수를 만들었습니다.
- 여기서 주의해야할 점은 0의 개수입니다. 0은 수의 맨 앞에 위치할 수 없으므로 각 수의 0을 0 다음으로 작은 숫자의 위치와 변경해주어야 합니다. 이 과정에서 다음과 같은 경우의 수가 생깁니다.
    1. 주어진 숫자열의 길이가 짝수 && 0의 개수가 짝수
    2. 주어진 숫자열의 길이가 짝수 && 0의 개수가 홀수
    3. 주어진 숫자열의 길이가 홀수 && 0의 개수가 짝수
    4. 주어진 숫자열의 길이가 홀수 && 0의 개수가 홀수
- 위 경우의 수 중에서 1, 2, 3의 경우는 상관없지만 4번의 경우는 위 규칙대로 두 개의 수를 생성하면 잘못된 해를 찾게 됩니다.(규칙이 번갈아 숫자를 부여하여 수를 만들기 때문)
- 그래서 4번의 경우에만 0을 하나 제거하여 3번의 경우로 만들어 숫자를 배분한 후, 만들어진 두 수 중에서 더 작은 수에 0을 부여하여 최종 수를 만드는 방법으로 문제를 해결하였습니다.

---

### 문제 3: 과일 탕후루

**문제 난이도**

- 실버 2

**문제 유형**

- 구현, 브루트포스 알고리즘, 두 포인터

**접근 방식 및 풀이**

- left, right 투 포인터를 사용하여 문제를 해결하였습니다.
- 처음에는 left가 0, right가 n-1을 가리키도록 설정하고 left~right까지 과일 종류의 개수가 3 이상이면 left+1 or right-1로 구현하였습니다. 이 로직을 재귀방식과 for문 방식으로 각각 구현해 보았지만 모두 시간 초과가 났습니다. 그래서 다른 방식으로 구현하였습니다.
- 꼬치에 꽂혀있는 과일의 종류와 개수를 저장하는 map을 생성하고 left와 right가 0을 가리키며 시작합니다. 그리고 right가 n-1이 될 때 까지 아래 과정을 반복합니다.
    - right를 한 칸 움직입니다. (= right+1)
    - right번째 과일을 map에 하나 추가합니다.
    - map의 크기가 3 이상이라면 2이하가 될 때까지 아래 과정을 반복합니다.
        - left번째의 과일을 map에서 제거합니다.
- 문제를 처음 읽고 완성되어 있는 탕후루에서 과일을 빼는 것을 생각했는데, 반대로 주어진 순서대로 과일을 조건(과일 종류가 2가지 이하)에 맞게 추가하는 것으로 생각하는 것이 포인트인 문제였다고 생각합니다.

---

### 문제 4: 작은 벌점

**문제 난이도**

- 골드 5

**문제 유형**

- 브루트포스 알고리즘, 정렬, 이분 탐색

**접근 방식 및 풀이**

- 각각의 배열에서 꺼낸 원소들이 서로 차이가 가장 적어야 최댓값 최솟값의 차이도 가장 작기 때문에 정렬을 한 후 배열의 길이가 가장 작은 배열을 기준으로 아래 과정을 반복하여 최솟값을 찾아냈습니다.
    - 배열의 원소를 하나 선택합니다.
    - 다른 두 배열에서 각각 선택한 원소의 값과 가장 차이가 작은 원소를 찾아냅니다.
    - 찾아낸 원소끼리 계산을 수행하여 최솟값을 찾습니다.
- 특정 원소를 찾아내는 것이 아닌, 크기가 비슷한 원소를 찾아내는 것이기 때문에 이분 탐색의 retrun값을 int배열로 설정하였습니다. 이때 비슷한 원소를 하나로 특정하지 않고 모두 반환한 이유는 비슷한 값을 찾는 배열이 두 개이기 때문에 각각의 조합에서 최솟값을 찾기 위함이었습니다.

---

### 문제 5: 이진 트리

**문제 난이도**

- 골드 3

**문제 유형**

- DP, 트리, 트리에서의 DP

**접근 방식 및 풀이**

- 모든 루프-리프까지의 엣지 합이 같으면서 모든 엣지 합이 최소가 되기 위해서는 루프-리프까지의 엣지 합이 가장 큰 값으로 통일해줘야 한다고 생각했습니다. 그래서 먼저 루트-리프까지의 엣지 합의 최댓값을 찾았습니다.
- 모든 엣지 합이 최소가 되기 위해서는 각각의 루프-리프 엣지 합을 구할 때 가장 많이 반복되어 사용되는 엣지의 가중치를 가장 크게 만들어야 합니다.
- 그래서 가장 상위의 엣지부터 가능한 가장 큰 값을 부여하며 문제를 해결하였습니다. 과정은 아래와 같습니다.
    - 문제의 트리를 각 엣지의 가중치를 값으로 갖는 노드와 루프 값이 0인 새로운 트리(=tree)로 생각하여 배열로 해당 트리를 생성하고 초기화하였습니다.
    1. 각 루프-리프 값의 최댓값을 찾습니다.(=maxValue)
    2. tree에서 루프 값은 실제 트리에서 없는 엣지이기 때문에 0으로 초기화하고, visited도 true로 초기화합니다.
    3. 높이가 1~n까지 각 노드들의 값을 아래 과정에 따라 재설정해줍니다.
        1. 해당 노드를 방문하지 않았다면 maxValue-(해당 노드의 부모~루프노드까지의 합)으로 설정하고 방문처리를 해줍니다.
        2. 방문을 했다면 해당 노드의 값과 maxValue-(해당 노드의 부모\~루프노드까지의 합+해당 노드의 자식 노드\~리프노드까지의 합) 중 더 작은 값으로 설정해줍니다.