### PR TITLE
[권혁준-알고리즘 스터디 4주차]

### DIFF
--- a/권혁준_4주차/[BOJ-9252] LCS 2.java
+++ b/권혁준_4주차/[BOJ-9252] LCS 2.java
@@ -1,0 +1,67 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+    static int[][] dp;
+    static int N, M;
+    static String A, B;
+
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+        A = br.readLine();
+        B = br.readLine();
+
+        N = A.length();
+        M = B.length();
+        dp = new int[N+1][M+1];
+
+	}
+	
+	static void solve() throws Exception{
+
+        for(int i=1;i<=N;i++) for(int j=1;j<=M;j++){
+            dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]);
+            if(A.charAt(i-1) == B.charAt(j-1)){
+                dp[i][j] = Math.max(dp[i][j], dp[i-1][j-1] + 1);
+            }
+        }
+
+        List<Character> ans = new ArrayList<>();
+        int i = N, j = M;
+        while(i>0 && j>0){
+            while(j>0 && dp[i][j] == dp[i][j-1]) j--;
+            while(i>0 && dp[i][j] == dp[i-1][j]) i--;
+            if(j==0) break;
+            ans.add(B.charAt(j-1));
+            j--;
+            i--;
+        }
+        
+        bw.write(ans.size() + "\n");
+        for(int k=ans.size()-1;k>=0;k--) bw.write(ans.get(k));
+
+	}
+	
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 4주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **LCS 2**
  - [ ] **숫자 더하기**  
  - [ ] **과일 탕후루**
  - [x] **작은 벌점**  
  - [ ] **이진 트리**  
---
  - [ ] **출근 기록**
  - [ ] **죽음의 비**

## 💡 풀이 방법
### 문제 1: LCS 2

**문제 난이도**

Gold 4

**문제 유형**

DP

 **접근 방식 및 풀이**

- 2차원 DP로 접근했습니다. `dp[i][j] = A[1:i]와 B[1:j]의 LCS 길이`
- 두 문자열을 $A, B$로 두면, $dp[i][j] = \max(dp[i-1][j], dp[i][j-1])$입니다.
- 만약 $A_i = B_j$라면, $dp[i-1][j-1] + 1$의 값으로 갱신할 수 있습니다.
- 정답 문자열을 추적할 때는, dp[N][M]부터 시작해서 대각선으로의 dp값이 줄어드는 지점을 찾아서 리스트에 담아줬습니다.
   
---
### 문제 2: 숫자 더하기

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---
### 문제 3: 과일 탕후루

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---
### 문제 4: 작은 벌점

**문제 난이도**

Gold 5

**문제 유형**

정렬, 투 포인터

 **접근 방식 및 풀이**

- 이분 탐색 문제였지만, 투 포인터로도 가능해 보여서 투 포인터로 해결했습니다.
- 우선, 플레이어 A가 고르는 수는 반복문으로 하나씩 찾아 고정시켜 줍니다.
- 플레이어 B, C가 고르는 수는 완전 탐색으로 구할 수 없고, 효율적으로 찾아줘야 시간 내에 문제를 풀 수 있습니다.
- 만약 B와 C의 카드 목록이 정렬되어 있다면, A가 고른 수가 고정된 값이기 때문에 B, C가 각각 고른 수 중 더 작은 값에 대해서만 포인터를 증가시켜주면 투 포인터 알고리즘이 성립합니다.
- 구체적으로 각 플레이어가 현재 고른 수들을 a, b, c라고 하면, 벌점을 최소화하기 위한 이동은, b와 c중 더 작은 값을 가진 수를 높이는 방법이 최선입니다.
   
---### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

   
---