### PR TITLE
[권혁준-5주차 알고리즘 스터디]

### DIFF
--- a/권혁준_5주차/[BOJ-12101] 1, 2, 3 더하기 2.cpp
+++ b/권혁준_5주차/[BOJ-12101] 1, 2, 3 더하기 2.cpp
@@ -1,0 +1,25 @@
+#include <iostream>
+#include <string>
+#include <algorithm>
+using namespace std;
+
+int N, K, cnt = 0;
+string ans = "-1";
+
+void bck(int sum, string s) {
+	if (sum == N) {
+		if (++cnt == K) ans = s;
+		return;
+	}
+	for (int i = 1; i <= min(3, N - sum); i++) bck(sum + i, s + "+" + to_string(i));
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> K;
+	for (int i = 1; i <= min(N,3); i++) bck(i, to_string(i));
+	cout << ans;
+
+}

--- a/권혁준_5주차/[BOJ-16401] 과자 나눠주기.cpp
+++ b/권혁준_5주차/[BOJ-16401] 과자 나눠주기.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int M, N;
+	cin >> M >> N;
+	vector<int> A(N);
+	for (int &i : A) cin >> i;
+	
+	int s = 0, e = 1e9, m = (s + e + 1) >> 1;
+	while (s < e) {
+		int r = 0;
+		for (int &i : A) r += i / m;
+		if (r >= M) s = m;
+		else e = m - 1;
+		m = (s + e + 1) >> 1;
+	}
+	cout << m;
+
+}

--- a/권혁준_5주차/[BOJ-16964] DFS 스페셜 저지.cpp
+++ b/권혁준_5주차/[BOJ-16964] DFS 스페셜 저지.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <vector>
+#include <set>
+using namespace std;
+
+set<int> S[100001]{};
+int par[100001]{}, vis[100001]{}, cnt[100001]{};
+int N;
+
+void dfs(int n, int p) {
+	par[n] = p;
+	for (int i : S[n]) {
+		if (i == p) continue;
+		dfs(i, n);
+	}
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 1, a, b; i < N; i++, S[a].insert(b), S[b].insert(a)) cin >> a >> b;
+	dfs(1, 0);
+
+	int r;
+	cin >> r;
+	if (r != 1) return cout << 0, 0;
+	vis[r] = 1;
+	for (int i = 2, a; i <= N; i++) {
+		cin >> a;
+		if (vis[a]) return cout << 0, 0;
+		if (S[r].count(a)) {
+			cnt[r]++;
+			vis[a]++;
+		}
+		else {
+			while (r != 0) {
+				if (cnt[r] == S[r].size() - 1) r = par[r];
+				else return cout << 0, 0;
+				if (S[r].count(a)) {
+					cnt[r]++;
+					vis[a]++;
+					break;
+				}
+			}
+		}
+		r = a;
+	}
+	cout << 1;
+
+}

--- a/권혁준_5주차/[BOJ-16973] 직사각형 탈출.cpp
+++ b/권혁준_5주차/[BOJ-16973] 직사각형 탈출.cpp
@@ -1,0 +1,52 @@
+#include <iostream>
+#include <queue>
+#include <tuple>
+using namespace std;
+
+int dx[4] = { 1,0,-1,0 };
+int dy[4] = { 0,1,0,-1 };
+int N, M, S[1001][1001]{}, H, W, sx, sy, ex, ey;
+bool vis[1001][1001]{};
+
+bool wall(int x, int y) { return S[x][y] - S[x - H][y] - S[x][y - W] + S[x - H][y - W] > 0; }
+
+bool can(int x, int y) {
+	return 1 <= x - H + 1 && x <= N && 1 <= y - W + 1 && y <= M && !wall(x, y);
+}
+
+int bfs(int p, int q) {
+	queue<tuple<int, int, int>> Q;
+	Q.emplace(p, q, 0);
+	vis[p][q] = true;
+	while (!Q.empty()) {
+		auto [x, y, t] = Q.front();
+		Q.pop();
+		if (x == ex && y == ey) return t;
+		for (int i = 0; i < 4; i++) {
+			int xx = x + dx[i], yy = y + dy[i];
+			if (can(xx, yy) && !vis[xx][yy]) {
+				vis[xx][yy] = true;
+				Q.emplace(xx, yy, t + 1);
+			}
+		}
+	}
+
+	return -1;
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> M;
+	for (int i = 1; i <= N; i++) for (int j = 1; j <= M; j++) {
+		cin >> S[i][j];
+		S[i][j] += S[i - 1][j] + S[i][j - 1] - S[i - 1][j - 1];
+	}
+	cin >> H >> W >> sx >> sy >> ex >> ey;
+	sx += H - 1, sy += W - 1;
+	ex += H - 1, ey += W - 1;
+
+	cout << bfs(sx, sy);
+	
+}

--- a/권혁준_5주차/[BOJ-17144] 미세먼지 안녕!.cpp
+++ b/권혁준_5주차/[BOJ-17144] 미세먼지 안녕!.cpp
@@ -1,0 +1,75 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int dx[4] = { 1,0,-1,0 };
+int dy[4] = { 0,1,0,-1 };
+int R, C, T, A[50][50]{}, K = -1;
+
+void spread() {
+	int NA[50][50]{};
+	for (int i = 0; i < R; i++) for (int j = 0; j < C; j++) {
+		if (A[i][j] <= 0) {
+			if (A[i][j] == -1) NA[i][j] = A[i][j];
+			continue;
+		}
+		int cnt = 0, val = A[i][j] / 5;
+		for (int k = 0; k < 4; k++) {
+			int x = i + dx[k], y = j + dy[k];
+			if (x < 0 || x >= R || y < 0 || y >= C || A[x][y] == -1) continue;
+			cnt++;
+			NA[x][y] += val;
+		}
+		NA[i][j] += A[i][j] - cnt * val;
+	}
+	for (int i = 0; i < R; i++) for (int j = 0; j < C; j++) A[i][j] = NA[i][j];
+}
+
+void cycle() {
+	int x = 0, y = 0, temp = A[x][y], dir = 1;
+	while (x != 1 || y != 0) {
+		int nx = x + dx[dir], ny = y + dy[dir];
+		if (nx < 0 || nx > K || ny < 0 || ny >= C) {
+			dir = (dir + 3) % 4;
+			nx = x + dx[dir], ny = y + dy[dir];
+		}
+		if (A[x][y] != -1) A[x][y] = max(0, A[nx][ny]);
+		x = nx, y = ny;
+	}
+	A[x][y] = temp;
+
+	x = R - 1, y = 0, temp = A[x][y], dir = 1;
+	while (x != R - 2 || y != 0) {
+		int nx = x + dx[dir], ny = y + dy[dir];
+		if (nx <= K || nx >= R || ny < 0 || ny >= C) {
+			dir = (dir + 1) % 4;
+			nx = x + dx[dir], ny = y + dy[dir];
+		}
+		if (A[x][y] != -1) A[x][y] = max(0, A[nx][ny]);
+		x = nx, y = ny;
+	}
+	A[x][y] = temp;
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> R >> C >> T;
+	for (int i = 0; i < R; i++) for (int j = 0; j < C; j++) {
+		cin >> A[i][j];
+		if (A[i][j] == -1 && K == -1) K = i;
+	}
+
+	while (T-- > 0) {
+		spread();
+		cycle();
+		
+	}
+
+	int ans = 0;
+	for (int i = 0; i < R; i++) for (int j = 0; j < C; j++) ans += max(A[i][j], 0);
+	cout << ans;
+
+}

--- a/권혁준_5주차/[BOJ-20207] 달력.cpp
+++ b/권혁준_5주차/[BOJ-20207] 달력.cpp
@@ -1,0 +1,41 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N;
+	cin >> N;
+	vector<pair<int, int>> arr(N);
+	for (auto &[s, e] : arr) cin >> s >> e;
+	sort(arr.begin(), arr.end(), [](auto a, auto b) -> bool {return a.first == b.first ? a.second > b.second : a.first < b.first; });
+
+	bool vis[1000]{};
+	int h = 1, cnt[366]{}, c = N;
+	while (c > 0) {
+		int p = 0;
+		for (int i = 0; i < N; i++) {
+			if (vis[i]) continue;
+			auto &[s, e] = arr[i];
+			if (s <= p) continue;
+			p = e;
+			vis[i] = 1;
+			c--;
+			for (int j = s; j <= e; j++) cnt[j] = h;
+		}
+		h++;
+	}
+
+	int ans = 0;
+	for (int i = 1; i <= 365; i++) {
+		if (!cnt[i]) continue;
+		int j = i, mx = 0;
+		while (i <= 365 && cnt[i]) mx = max(mx, cnt[i++]);
+		ans += mx * (i - j);
+	}
+	cout << ans;
+
+}

--- a/권혁준_5주차/[BOJ-2228] 구간 나누기.cpp
+++ b/권혁준_5주차/[BOJ-2228] 구간 나누기.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+
+int D[101][51]{}, X[101][51]{}, S[101]{}, N, M;
+const int INF = -1234567890;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	for (int i = 1; i <= 100; i++) for (int k = 1; k <= 50; k++) D[i][k] = INF, X[i][k] = INF;
+
+	cin >> N >> M;
+	for (int i = 1; i <= N; i++) cin >> S[i], S[i] += S[i - 1];
+
+	D[1][1] = S[1], X[1][1] = S[1];
+	for (int n = 2; n <= N; n++) {
+		for (int i = 1; n - i >= 0; i++) D[n][1] = max(D[n][1], S[n] - S[n - i]);
+		X[n][1] = max(X[n - 1][1], D[n][1]);
+		for (int k = 2; k <= M; k++) {
+			for (int i = 1; 2 * k - 2 <= n - i; i++) D[n][k] = max(D[n][k], X[n - i - 1][k - 1] + S[n] - S[n - i]);
+			X[n][k] = max(X[n - 1][k], D[n][k]);
+		}
+	}
+	cout << X[N][M];
+
+}

--- a/권혁준_5주차/[BOJ-2250] 트리의 높이와 너비.java
+++ b/권혁준_5주차/[BOJ-2250] 트리의 높이와 너비.java
@@ -1,0 +1,80 @@
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static boolean[] hasParent;
+	static int[] min, max;
+	static int N;
+	static int[] left, right;
+	static int cnt = 0, ans = 0, dep = 0;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		min = new int[10001];
+		max = new int[10001];
+		Arrays.fill(min, 100000);
+		Arrays.fill(max, -1);
+		
+		N = Integer.parseInt(br.readLine());
+		hasParent = new boolean[N+1];
+		left = new int[N+1];
+		right = new int[N+1];
+		for(int i=1;i<=N;i++) {
+			nextLine();
+			int n = nextInt(), l = nextInt(), r = nextInt();
+			left[n] = l;
+			right[n] = r;
+			if(l != -1) hasParent[l] = true;
+			if(r != -1) hasParent[r] = true;
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int i=1;i<=N;i++) if(!hasParent[i]) {
+			dfs(i,1);
+			break;
+		}
+		for(int i=1;i<=10000;i++) {
+			int diff = max[i] - min[i] + 1;
+			if(diff > ans) {
+				ans = diff;
+				dep = i;
+			}
+		}
+		bw.write(dep+" "+ans);
+		
+	}
+	
+	static void dfs(int n, int d) {
+		if(left[n] != -1) dfs(left[n], d+1);
+		cnt++;
+		min[d] = Math.min(cnt, min[d]);
+		max[d] = Math.max(cnt, max[d]);
+		if(right[n] != -1) dfs(right[n], d+1);
+	}
+	
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 5주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 8문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **1, 2, 3 더하기 2**
  - [x] **달력**  
  - [x] **과자 나눠주기**
  - [x] **구간 나누기**  
  - [x] **미세먼지 안녕!**  
---
  - [x] **DFS 스페셜 저지**  
  - [x] **트리의 높이와 너비**
  - [x] **직사각형 탈출**


## 💡 풀이 방법
### 문제 1: 1, 2, 3 더하기 2

**문제 난이도**

Silver 1

**문제 유형**

- 백트래킹

 **접근 방식 및 풀이**

- 재귀 함수로 수를 1, 2, 3 차례대로 더해주며 합이 N이 되는 시점에 종료되도록 구현했습니다.
- 재귀 함수의 인자로 정답 문자열을 직접 전달했습니다.

## Trouble shooting
- 1, 2, 3만 써야하는 걸 못 보고 풀어서 두 번 틀렸습니다. -> 요즘 문제를 제대로 안 읽고 푸는 경향이 있는 것 같아 주의하겠습니다.

---


### 문제 2: 달력

**문제 난이도**

Gold 5

**문제 유형**

- 정렬
- 구현

 **접근 방식 및 풀이**

- 일정을 정렬하고 시작했습니다. 기준은 시작 날짜의 오름차순, 같다면 종료 날짜의 내림차순으로 잡았습니다.
- 길이가 365인 달력 배열을 생성하고, 문제에 나와있는 그림대로 일정을 하나씩 쌓아줬습니다.
- 코팅지의 면적을 구할 때는, 달력 배열에서 끊기지 않은 길이를 구하고 그 구간의 최댓값을 곱해서 구했습니다.

---



### 문제 3: 과자 나눠주기

**문제 난이도**

Silver 2

**문제 유형**

- 매개 변수 탐색
- 이분 탐색

 **접근 방식 및 풀이**

- 이 문제는, 조카들에게 막대과자의 길이를 모두 같게 나누어줄 수 있는 최대 길이를 구하는 **최적화 문제**입니다.
1. 만약 문제가 `길이가 $k$인 막대과자를 조카들에게 나누어줄 수 있는가?` 였다면, 이 문제는 가능/불가능 여부를 판별하는 **결정 문제**가 됩니다.
2. 또한, 길이가 $k$인 막대과자를 나누어줄 수 있다면, 길이가 $k-1$인 막대과자 또한 나누어줄 수 있습니다.

- 이 두 성질을 관찰하여 다음과 같은 풀이로 해결했습니다.
1. $k$의 범위를 초기에 $[1, 10^9]$로 잡고 이분 탐색으로 위의 **결정 문제**를 해결합니다.
2. 가능/불가능 여부에 따라 $k$값으로 가능한 범위를 조절합니다.
3. 과정 1~2를 $k$값이 유일해질 때까지 반복합니다.

---



### 문제 4: 구간 나누기

**문제 난이도**

Gold 3

**문제 유형**

- DP
- 누적 합

 **접근 방식 및 풀이**

- 2차원 DP배열을 정의했습니다. `DP[n][k] = 첫 번째부터 n번째 수까지, 구간이 총 $k$개이고 $n$번째 수는 반드시 구간에 포함되어 있을 때의 구간 합의 최댓값`
- 그럼, $n$번째 수가 포함된 구간으로 가능한 경우는 아래와 같습니다.
1. { A[n] }
2. { A[n-1], A[n] }
3. { A[n-2], A[n-1], A[n] }
$\vdots$

- 따라서, 다음과 같은 DP식을 도출해낼 수 있습니다. 
- $DP[n][k] = \max((A[n] + ... + A[n-i+1]) + \max(DP[1][k-1], \cdots, DP[n-i-1][k-1]))$
- 이 식을 빠르게 계산하기 위해 A 배열의 누적 합, DP배열의 max값을 관리하는 배열을 추가로 정의해서 해결했습니다.

---



### 문제 5: 미세먼지 안녕!

**문제 난이도**

Gold 4

**문제 유형**

- 시뮬레이션

 **접근 방식 및 풀이**

- 두 가지 함수로 나누어 해결했습니다.

1. spread
- 미세먼지의 확산을 처리하는 함수입니다.
- 동시에 확산이 이루어지기 때문에, 확산의 결과가 동시간대의 다른 칸에 영향을 미쳐서는 안됩니다.
- 따라서, 맵을 새로 만들어 확산을 진행한 뒤에 기존 맵에 덮어쓰는 방식으로 구현했습니다.

2. cycle
- 공기청정기가 존재하는 행을 따로 전역 변수로 저장했습니다.
- 위쪽 부분은 반시계 방향으로, 아래쪽 부분은 시계 방향으로 경계를 한 바퀴 돌듯이 구현했습니다.
---
## Trouble shooting
1. cycle 함수에서 공기청정기를 나타내는 -1까지 같이 돌아가는 문제가 있었습니다.
2. spread 함수에서 맵을 덮어쓸 때 기존의 공기청정기 위치를 덮어쓰지 못하는 문제가 있었습니다.
- 각 스텝마다 맵을 직접 출력해보며 디버깅해서, 공기청정기가 사라지는 문제를 먼저 찾았습니다. 찾고 난 뒤에는, 공기청정기가 같이 돌아가버리는 문제를 찾을 수 있었습니다.

---


### 문제 6: DFS 스페셜 저지

**문제 난이도**

Gold 3

**문제 유형**

- Set
- 깊이 우선 탐색
- 트리

 **접근 방식 및 풀이**

- 트리를 생성할 때, 간선을 vector대신 set에 넣어줬습니다.
- DFS 방문 순서가 주어지면, 올바른 이동인지 확인하기 위함입니다.

## 방문 순서의 유효성 판별
- 먼저, 루트는 항상 1이기 때문에 순서의 처음이 1인지 확인합니다.
- 다음부터는, 원래 있던 정점을 r, 다음 정점을 a라 할 때, r에서 a로 갈 수 있는지 여부를 set을 통해 확인합니다.
- 갈 수 있다면, a로 갑니다.
- 갈 수 없다면, r에서의 subtree의 탐색을 마쳤어야지만 유효한 경우이므로 이를 확인합니다.
- 유효한 경우였다면 r을 부모로 올리고 위의 과정을 반복합니다.

---


### 문제 7: 트리의 높이와 너비

**문제 난이도**

Gold 2

**문제 유형**

- 깊이 우선 탐색
- 트리

 **접근 방식 및 풀이**

- 잘 관찰하면, 각 정점의 열 번호는 주어진 트리를 Inorder로 순회했을 때의 방문 순서와 같습니다.
- DFS로 이를 구해줍니다.
- DFS를 수행할 때, 함수의 인자로 레벨을 같이 전달하여, 각 레벨 별 min, max값을 매번 갱신해 주었습니다.

## Trouble shooting
- 트리의 루트 노드를 항상 1이라고 가정하고 풀었는데, 1이 아닐수도 있었습니다.

---


### 문제 8: 직사각형 탈출

**문제 난이도**

Gold 4

**문제 유형**

- 누적 합
- 너비 우선 탐색

 **접근 방식 및 풀이**

- 2차원 누적 합을 이용해서, 직사각형의 이동 가능 여부를 $O(1)$에 판별할 수 있습니다.
- BFS를 돌려 정답을 구했습니다.

## Trouble shooting
- 로직상 틀린 부분이 전혀 없는 것 같아, 게시판에서 공유된 반례들을 하나씩 넣어봤습니다.
- 결론적으로, 틀린 원인은 참조 연산자(&) 때문이었습니다.
- `auto &[x, y, t] = Q.front();`에서 &연산자는 참조를 의미하는데, Q가 pop된 이후 처음으로 push될 때, x, y, t값이 새로 push된 값을 참조한다는 사실을 발견했습니다.