### PR TITLE
[유병규-5주차 알고리즘 스터디]

### DIFF
--- a/유병규_5주차/[BOJ-12101] 1, 2, 3 더하기 2.java
+++ b/유병규_5주차/[BOJ-12101] 1, 2, 3 더하기 2.java
@@ -1,0 +1,38 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	private static int n;
+	private static String result = "-1";
+	private static List<String> list = new ArrayList<>();
+	private static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+    	StringTokenizer st = new StringTokenizer(br.readLine());
+    	n = Integer.parseInt(st.nextToken());
+    	int k = Integer.parseInt(st.nextToken());
+
+    	backTracking(0);
+    	if(list.size() >= k) {
+    		result = list.get(k-1).substring(1, list.get(k-1).length());
+    	}
+    	System.out.println(result);
+    }
+
+
+    private static void backTracking(int currentSum) {
+    	if(currentSum >= n) {
+    		if(currentSum == n) {
+    			list.add(sb.toString());
+    		}
+    		return;
+    	}
+
+    	for(int i=1; i<=3; i++) {
+    		sb.append("+").append(i);
+    		backTracking(currentSum+i);
+    		sb.delete(sb.length()-2, sb.length());
+    	}
+    }
+}

--- a/유병규_5주차/[BOJ-16401] 과자 나눠주기.java
+++ b/유병규_5주차/[BOJ-16401] 과자 나눠주기.java
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int m = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+        st = new StringTokenizer(br.readLine());
+
+        int[] snacks = new int[n];
+        for(int i=0; i<n; i++) {
+            snacks[i] = Integer.parseInt(st.nextToken());
+        }
+        Arrays.sort(snacks);
+
+        int result = 0;
+
+        int left = 1;
+        int right = snacks[n-1];
+
+        while(left <= right) {
+            int mid = (left+right)/2;
+
+            int count = 0;
+            for(int i=n-1; i>=0; i--) {
+                count += snacks[i]/mid;
+                if(count >= m) {
+                    result = mid;
+                    break;
+                }
+            }
+
+            if(count < m) right = mid-1;
+            else left = mid+1;
+        }
+
+        System.out.println(result);
+    }
+}

--- a/유병규_5주차/[BOJ-20207] 달력.java
+++ b/유병규_5주차/[BOJ-20207] 달력.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+    public static void main(String[] args) throws IOException {
+
+        int[] calendar = new int[366];
+        int n = Integer.parseInt(br.readLine());
+        for (int repeat = 0; repeat < n; repeat++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            for (int i = start; i <= end; i++) {
+                calendar[i]++;
+            }
+        }
+
+        int total = 0;
+        int width = 0, height = 0;
+        for (int i = 1; i <= 365; i++) {
+            if (calendar[i-1] == 0 && calendar[i] != 0) {
+                width = 1;
+                height = calendar[i];
+                continue;
+            }
+            if (calendar[i - 1] != 0 && calendar[i] != 0) {
+                width++;
+                height = Math.max(height, calendar[i]);
+                continue;
+            }
+            if (calendar[i-1] != 0 && calendar[i] == 0) {
+                total += width*height;
+                width = 0;
+                height = 0;
+                continue;
+            }
+        }
+        total += width*height;
+        System.out.println(total);
+    }
+}

--- a/유병규_5주차/[BOJ-2228] 구간 나누기.java
+++ b/유병규_5주차/[BOJ-2228] 구간 나누기.java
@@ -1,0 +1,45 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    private static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    private static int[] numbers;
+
+    public static void main(String[] args) throws IOException {
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        numbers = new int[n+1];
+        for(int i=1; i<=n; i++) {
+            numbers[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[][] dp = new int[n+1][m+1];
+        Arrays.fill(dp[0], -32768*100);
+
+        dp[0][0] = 0;
+        for(int i=1; i<=n; i++) {
+            for(int j=1; j<=m; j++) {
+                dp[i][j] = dp[i-1][j];
+                for(int k=i-2; k>=0; k--) {
+                    if((k+1)/2 < j-1) continue;
+                    dp[i][j] = Math.max(dp[i][j], dp[k][j-1]+sum(k+2, i));
+                }
+                if(j==1) {
+                    dp[i][j] = Math.max(dp[i][j], sum(1, i));
+                }
+            }
+        }
+
+        System.out.println(dp[n][m]);
+    }
+
+    private static int sum(int start, int end) {
+        int sum=0;
+        for(int i=start; i<=end; i++) {
+            sum += numbers[i];
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 5주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **1, 2, 3 더하기 2**
- [x]  **달력**
- [x]  **과자 나눠주기**
- [x]  **구간 나누기**
- [ ]  **미세먼지 안녕!**

---

- [ ]  **DFS 스페셜 저지**
- [ ]  **트리의 높이와 너비**
- [ ]  **직사각형 탈출**

---

## 💡 풀이 방법

### 문제 1: 1, 2, 3 더하기 2

**문제 난이도**

- 실버 1

**문제 유형**

- 브루트포스 알고리즘, 백트래킹

**접근 방식 및 풀이**

- 0 ≤ n ≤ 11 이기 때문에 재귀로 해결 가능하다 생각하여 백트래킹으로 구현하였습니다.
- 1, 2, 3의 숫자로 만들 수 있는 식을 모두 찾은 후 K 번째 식을 구하였습니다. 이때, 1부터 순차적으로 식을 찾기 때문에 따로 정렬을 하지 않아도 답을 구할 수 있었습니다.

---

### 문제 2:  달력

**문제 난이도**

- 골드 5

**문제 유형**

- 구현, 그리디 알고리즘, 정렬

**접근 방식 및 풀이**

- 직사각형 넓이를 구하는 것이고 코팅지가 곂치는 부분은 아래로 이동하여 직사각형의 높이가 길어지므로 가장 많이 곂치는 부분을 구하여 문제를 해결하였습니다.
- 1\~365를 표시할 수 있는 배열을 만들고, 시작일\~종료일까지에 해당하는 일에 +1씩 값을 수정하여 가장 많이 곂치는 부분의 값을 체크하였습니다. 그리고 배열을 순회하며 직사각형이 생기는 부분의 넓이를 계산한 후 이를 더하여 답을 구하였습니다.

---

### 문제 3: 과자 나눠주기

**문제 난이도**

- 실버 2

**문제 유형**

- 이분 탐색, 매개 변수 탐색

**접근 방식 및 풀이**

- 나눠줄 과자의 길이가 1부터 시작해서 가능한 길이인지 확인하고 길이를 1씩 늘려가며 최댓값을 찾았습니다. 이 방법은 1부터 모든 길이를 해보는 것이기 때문에 시간을 줄이기 위해서 정렬을 한 뒤 높은 길이부터 나눠서 몇 개의 과자로 분리되는 지 확인하고, 만약 해당 길이로 분리시킬 수 없다면 해당 길이로 탐색하는 걸 멈추고 다음 길이로 계산하도록 진행하였습니다. 하지만 이 방법을 사용하니 시간 초과가 나서 결국 해결하지 못했습니다.
- 이 문제는 이분 탐색을 사용하는 문제라고 나와있어서 어떻게 이분 탐색을 활용할 수 있는지 고민하였습니다. 가능한 과자의 길이를 찾을 때 만약 길이 x로 나눠줄 수 있다면, x보다 작은 모든 길이로도 나눠줄 수 있고, 반대로 길이 x로 나눠줄 수 없다면, x보다 큰 모든 길이로도 나눠줄 수 없다는 것을 알게 되었습니다. 이를 이용하여 가능한 과자의 길이를 설정하고(1~과자들 중의 최대 길이) 이분 탐색으로 mid의 값(중간 길이)으로 나눠줄 수 있는지 판단하며 값을 찾아나갔습니다.

---

### 문제 4: 구간 나누기

**문제 난이도**

- 골드 3

**문제 유형**

- 다이나믹 프로그래밍

**접근 방식 및 풀이**

- 숫자열의 마지막 숫자를 기준으로 다음과 같이 경우의 수를 나눠서 DP로 해결하였습니다.
      1. 마지막 숫자가 구간에 포함되지 않는 경우
      2. 마지막 숫자만 하나의 구간으로 포함하는 경우
      3. 마지막 숫자~K번째 숫자까지 하나의 구간으로 포함하는 경우
- dp[n][m]은 n번째 숫자까지의 숫자열에서 m개의 구간을 만들었을 때의 최대합을 의미합니다.
- 위의 경우의 수를 dp로 표현하면 다음과 같습니다.
      1. `dp[i][j] = dp[i-1][j]`
      2, 3. `dp[i][j] = max(dp[i-2][j-1] + sum(i~i), dp[i-3][j-1]+sum(i-1 ~ i) … , dp[k][j-1]+sum(k+2 ~ i)`
    
- 이때, `dp[i][j]`는 숫자의 개수와 구간의 개수이기 때문에 `(i+1)/2 ≥ j`를 만족해야 한다. 예를 들어, `dp[1][2]`의 경우 1번째 숫자까지의 숫자열에서 2개의 구간을 만드는 것인데 이는 불가능한 것이므로 dp 계산에 포함하지 않는 것이다.
- dp 계산에서 `dp[0][0]`은 0이지만` dp[0][j](j>0)`은 불가능한 경우이므로 최솟값으로 초기화하여 계산을 진행하였습니다.
- 처음에는 모든 값을 최솟값으로 초기화하였지만 이럴 경우 `dp[i][0]`의 값이 0임에도 최솟값으로 계산되는 문제가 있어 `dp[0][j](j>0)`인 부분만 최솟값으로 초기화하였습니다.

---

### 문제 5: 

**문제 난이도**

- 

**문제 유형**

- 

**접근 방식 및 풀이**

- 

---