### PR TITLE
[권혁준-6주차 알고리즘 스터디]

### DIFF
--- a/권혁준_6주차/[BOJ-12761] 돌다리.cpp
+++ b/권혁준_6주차/[BOJ-12761] 돌다리.cpp
@@ -1,0 +1,33 @@
+#include <iostream>
+#include <queue>
+#include <bitset>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int A, B, N, M;
+	cin >> A >> B >> N >> M;
+	bitset<100001> v;
+	queue<pair<int, int>> Q;
+	Q.emplace(N, 0);
+	v[N] = 1;
+
+	int d[6] = { 1,-1,A,-A,B,-B };
+	while (!Q.empty()) {
+		auto[n, t] = Q.front();
+		Q.pop();
+		if (n == M) return cout << t, 0;
+		for (int i = 0; i < 6; i++) {
+			int x = n + d[i];
+			if (x < 0 || x > 100000 || v[x]) continue;
+			v[x] = 1;
+			Q.emplace(x, t + 1);
+		}
+		if (n*A <= 100000 && !v[n*A]) { v[n*A] = 1; Q.emplace(n*A, t + 1); }
+		if (n*B <= 100000 && !v[n*B]) { v[n*B] = 1; Q.emplace(n*B, t + 1); }
+	}
+
+
+}

--- a/권혁준_6주차/[BOJ-16437] 양 구출 작전.cpp
+++ b/권혁준_6주차/[BOJ-16437] 양 구출 작전.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+using ll = long long;
+
+int N;
+vector<vector<int>> V(123457);
+ll C[123457]{};
+
+ll dfs(int n) {
+	ll res = C[n];
+	for (int i : V[n]) res += dfs(i);
+	return max(res, 0LL);
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N;
+	for (int i = 2, a, b; i <= N; i++) {
+		char o;
+		cin >> o >> a >> b;
+		V[b].push_back(i);
+		C[i] = a * (o == 'S' ? 1 : -1);
+	}
+
+	cout << dfs(1);
+
+}

--- a/권혁준_6주차/[BOJ-17090] 미로 탈출하기.cpp
+++ b/권혁준_6주차/[BOJ-17090] 미로 탈출하기.cpp
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <vector>
+#include <algorithm>
+using namespace std;
+using ll = long long;
+
+int N, M;
+char A[500][500]{};
+int vis[502][502]{};
+
+int dfs(int x, int y) {
+	if (x < 0 || x >= N || y < 0 || y >= M) return 1;
+	int xx, yy;
+	if (A[x][y] == 'U') xx = x - 1, yy = y;
+	if (A[x][y] == 'D') xx = x + 1, yy = y;
+	if (A[x][y] == 'L') xx = x, yy = y - 1;
+	if (A[x][y] == 'R') xx = x, yy = y + 1;
+
+	if (xx < 0 || xx >= N || yy < 0 || yy >= M) return vis[x][y] = 1;
+	if (!vis[xx][yy]) {
+		vis[xx][yy] = -1;
+		return vis[x][y] = dfs(xx, yy);
+	}
+	return vis[x][y] = vis[xx][yy];
+
+}
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> M;
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) cin >> A[i][j];
+
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) if (!vis[i][j]) {
+		vis[i][j] = -1;
+		vis[i][j] = dfs(i, j);
+	}
+
+	int ans = 0;
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) ans += vis[i][j] == 1;
+	cout << ans;
+
+}

--- a/권혁준_6주차/[BOJ-19237] 어른 상어.java
+++ b/권혁준_6주차/[BOJ-19237] 어른 상어.java
@@ -1,0 +1,160 @@
+import java.util.*;
+import java.io.*;
+
+class Shark{
+	int id, dir, x, y;
+	int[][] prior;
+	Shark(int id, int x, int y){
+		this.id = id;
+		this.x = x;
+		this.y = y;
+		prior = new int[5][5];
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	static final int[] dx = {0,-1,1,0,0};
+	static final int[] dy = {0,0,0,-1,1};
+	
+	static Shark[] sharks;
+	static boolean[] alive;
+	static int[][] A;
+	static int[][] smell_id, smell_time;
+	static int N, M, K, R;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		nextLine();
+		N = nextInt();
+		M = nextInt();
+		K = nextInt();
+		smell_id = new int[N][N];
+		smell_time = new int[N][N];
+		A = new int[N][N];
+		sharks = new Shark[M+1];
+		alive = new boolean[M+1];
+		Arrays.fill(alive, true);
+		R = M;
+		
+		
+		for(int i=0;i<N;i++) {
+			nextLine();
+			for(int j=0;j<N;j++) {
+				A[i][j] = nextInt();
+				if(A[i][j] != 0) {
+					Shark temp = new Shark(A[i][j], i, j);
+					sharks[A[i][j]] = temp;
+				}
+			}
+		}
+		
+		nextLine();
+		for(int i=1;i<=M;i++) sharks[i].dir = nextInt();
+		
+		for(int i=1;i<=M;i++) {
+			for(int k=1;k<=4;k++) {
+				nextLine();
+				for(int j=1;j<=4;j++) sharks[i].prior[k][j] = nextInt();
+			}
+		}
+		
+	}
+	
+	static void solve() throws Exception{
+
+		for(int time=0;time<1000;time++) {
+			SmellSpread();
+			MoveSharks();
+			SmellsTimeSpend();
+			if(R == 1) {
+				bw.write((time+1) + "\n");
+				return;
+			}
+		}
+		bw.write("-1");
+		
+	}
+	
+	static void SmellsTimeSpend() {
+		
+		for(int i=0;i<N;i++) for(int j=0;j<N;j++) {
+			if(smell_time[i][j] != 0) smell_time[i][j]--;
+			if(smell_time[i][j] == 0) smell_id[i][j] = 0;
+		}
+		
+	}
+	
+	static void SmellSpread() {
+		for(int i=1;i<=M;i++) if(alive[i]) {
+			int x = sharks[i].x, y = sharks[i].y;
+			smell_id[x][y] = sharks[i].id;
+			smell_time[x][y] = K;
+		}
+	}
+	
+	static void MoveSharks() {
+		
+		int[][] NA = new int[N][N];
+		for(int i=1;i<=M;i++) if(alive[i]) {
+			int dir = sharks[i].dir;
+			
+			boolean done = false;
+			for(int k=1;k<=4;k++) {
+				int x = sharks[i].x + dx[sharks[i].prior[dir][k]];
+				int y = sharks[i].y + dy[sharks[i].prior[dir][k]];
+				if(x<0 || x>=N || y<0 || y>=N || smell_id[x][y] != 0) continue;
+				done = true;
+				if(NA[x][y] != 0) {
+					R--;
+					if(NA[x][y] < sharks[i].id) {
+						alive[sharks[i].id] = false;
+						break;
+					}
+					else alive[NA[x][y]] = false;
+				}
+				sharks[i].x = x;
+				sharks[i].y = y;
+				sharks[i].dir = sharks[i].prior[dir][k];
+				NA[x][y] = sharks[i].id;
+				break;
+			}
+			
+			if(done) continue;
+			for(int k=1;k<=4;k++) {
+				int x = sharks[i].x + dx[sharks[i].prior[dir][k]];
+				int y = sharks[i].y + dy[sharks[i].prior[dir][k]];
+				if(x<0 || x>=N || y<0 || y>=N || smell_id[x][y] != sharks[i].id) continue;
+				sharks[i].x = x;
+				sharks[i].y = y;
+				sharks[i].dir = sharks[i].prior[dir][k];
+				NA[x][y] = sharks[i].id;
+				break;
+			}
+		}
+		A = NA;
+		
+		
+	}
+	
+}

--- a/권혁준_6주차/[BOJ-2304] 창고 다각형.cpp
+++ b/권혁준_6주차/[BOJ-2304] 창고 다각형.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, Y[1001]{}, Z[1001]{};
+	cin >> N;
+	for (int i = 0, a, b; i < N; i++) {
+		cin >> a >> b;
+		Y[a] = b;
+	}
+
+	for (int i = 1; i <= 1000; i++) Z[i] = max(Z[i - 1], Y[i]);
+
+	int ans = 0, from_right = 0;
+	for (int i = 1000; i >= 1; i--) {
+		from_right = max(from_right, Y[i]);
+		Z[i] = min(Z[i], from_right);
+		ans += Z[i];
+	}
+	cout << ans;
+
+}

--- a/권혁준_6주차/[BOJ-2473] 세 용액.java
+++ b/권혁준_6주차/[BOJ-2473] 세 용액.java
@@ -1,0 +1,82 @@
+import java.util.*;
+import java.io.*;
+
+class Node{
+	int attacks = 0;
+	int mine = 0;
+	Node(int attacks, int mine){
+		this.attacks = attacks;
+		this.mine = mine;
+	}
+}
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N;
+	static long[] A;
+	static long res = Long.MAX_VALUE;
+	static long a, b, c;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+
+		N = Integer.parseInt(br.readLine());
+		A = new long[N];
+		nextLine();
+		for(int i=0;i<N;i++) A[i] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		Arrays.sort(A);
+		for(int i=0;i<N;i++) for(int j=i+1;j<N;j++) {
+			long tar = -(A[i] + A[j]);
+			int x = lowerBound(j+1, N, tar);
+			if(x-1 >= 0 && x-1 != j) check(A[i], A[j], A[x-1]);
+			if(0 <= x && x < N) check(A[i], A[j], A[x]);
+		}
+		bw.write(a + " " + b + " " + c);
+		
+		
+	}
+	
+	static void check(long x, long y, long z) {
+		if(Math.abs(x+y+z) < res) {
+			res = Math.abs(x+y+z);
+			a = x;
+			b = y;
+			c = z;
+		}
+	}
+	
+	static int lowerBound(int s, int e, long x) {
+		int m = (s+e)>>1;
+		while(s<e) {
+			if(A[m] < x) s = m+1;
+			else e = m;
+			m = (s+e)>>1;
+		}
+		return m;
+	}
+}

--- a/권혁준_6주차/[BOJ-2631] 줄세우기.cpp
+++ b/권혁준_6주차/[BOJ-2631] 줄세우기.cpp
@@ -1,0 +1,18 @@
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, arr[202]{}, dp[202]{}, ans = 0;
+	cin >> N;
+	for (int i = 1; i <= N; i++) {
+		cin >> arr[i];
+		for (int j = 0; j < i; j++) if (arr[i] > arr[j]) dp[i] = max(dp[i], dp[j] + 1);
+		ans = max(ans, dp[i]);
+	}
+	cout << N - ans;
+
+}

--- a/권혁준_6주차/[BOJ-30805] 사전 순 최대 공통 부분 수열.cpp
+++ b/권혁준_6주차/[BOJ-30805] 사전 순 최대 공통 부분 수열.cpp
@@ -1,0 +1,38 @@
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main()
+{
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, M;
+	cin >> N;
+	vector<int> A(N);
+	for (int &i : A) cin >> i;
+	cin >> M;
+	vector<int> B(M);
+	for (int &i : B) cin >> i;
+
+	vector<int> R;
+	int idxA = 0, idxB = 0;
+	while (idxA < N && idxB < M) {
+		bool suc = 0;
+		for (int x = 100; x >= 1; x--) {
+			int res = 0;
+			int new_idxA = idxA, new_idxB = idxB;
+			for (int i = idxA; i < N; i++) if (A[i] == x) { res++; new_idxA = i + 1; break; }
+			for (int i = idxB; i < M; i++) if (B[i] == x) { res++; new_idxB = i + 1; break; }
+			if (res == 2) {
+				idxA = new_idxA, idxB = new_idxB;
+				R.push_back(x);
+				suc = 1;
+				break;
+			}
+		}
+		if (!suc) break;
+	}
+	cout << R.size() << '\n';
+	for (int i : R) cout << i << ' ';
+
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 6주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 8문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **줄세우기**
  - [x] **세 용액**  
  - [x] **창고 다각형**
  - [x] **사전 순 최대 공통 부분 수열**  
  - [x] **돌다리**  
  ---
  - [x] **어른 상어**  
  - [x] **양 구출 작전**  
  - [x] **미로 탈출하기**

---

## 💡 풀이 방법
### 문제 1: 줄세우기

**문제 난이도**

- Gold 4

**문제 유형**

- DP

 **접근 방식 및 풀이**

이미 정렬되어 있는 최대 길이를 안다면, N - (해당 길이) 만큼의 학생을 그 사이에 적절히 끼워 넣는 방법이 통합니다.
  => Longest Increasing Subsequence를 구하는 문제로 바뀝니다.
N 제한이 작아, DP를 이용한 $O(N^2)$ LIS로 해결할 수 있습니다.

## Trouble shooting
원래는 `DP[x][y] = 작은 수에서 x개, 큰 수에서 y개까지만 양 끝에 정렬된 상태로 존재하게 하는 최소 이동 횟수`라고 정의하고 문제를 풀려 했습니다.
반례를 끝까지 못 찾았고, 게시판을 보다가 풀이를 봐버렸습니다..

---


### 문제 2: 세 용액

**문제 난이도**

- Gold 3

**문제 유형**

- 정렬
- 이분 탐색

 **접근 방식 및 풀이**

용액 두 개까지는 이중 반복으로 고정시켜놓으면 $O(N^2)$이라, 나머지 하나를 효율적으로 찾아야 합니다.

정렬된 배열에서 고정해놓은 두 용액 합 $\times$ -1 값을 이분 탐색으로 찾고, 그 앞 or 뒤로 인접한 값까지 같이 보며 정답을 갱신해나갈 수 있습니다.

---


### 문제 3: 창고 다각형

**문제 난이도**

- Silver 2

**문제 유형**

- 구현
- 브루트포스 알고리즘

 **접근 방식 및 풀이**

기둥이 놓이게 되는 밑변을 x축으로 보고, 길이 1001짜리 배열 Y를 만들어서 `Y[x] = x좌표에 대한 기둥의 높이`로 정의했습니다.

최소 다각형을 만들 때는, 넓은 천 하나를 위에서 떨어뜨린다고 생각하면 편합니다.

구체적으로는, 어떤 x좌표에 대한 다각형의 높이는 $\min(\max \limits_{1 \le i \le x} {Y[i]}, \max \limits_{x \le j \le 1000} {Y[j]})$입니다.

---


### 문제 4: 사전 순 최대 공통 부분 수열

**문제 난이도**

- Gold 4

**문제 유형**

- 그리디

 **접근 방식 및 풀이**

정답 수열을 만들 때는 당연하게도, 두 수열에서 공통된 원소 중 최댓값이 오게 됩니다.

만약 두 수열에서 공통된 최댓값의 인덱스가 각각 $i, j$였다면, 다음 공통 최댓값을 찾을 때는 각각 $i+1, j+1$번째 인덱스부터 찾아주면 됩니다.

---


### 문제 5: 돌다리

**문제 난이도**

- Silver 1

**문제 유형**

- BFS

 **접근 방식 및 풀이**

한 위치 x에서 할 수 있는 행동은 최대 8가지입니다.
 => { +1, -1, +A, -A, +B, -B, *A, *B }

1차원 BFS를 돌리면 됩니다.

---


### 문제 6: 어른 상어

**문제 난이도**

- Gold 2

**문제 유형**

- 구현
- 시뮬레이션

 **접근 방식 및 풀이**

세 가지 함수로 나누어 풀이했습니다.

### SmellSpread
상어가 현재 위치에 자신의 냄새를 뿌리게 하는 함수입니다.

### MoveSharks
상어들을 모두 다음 칸으로 이동시키고, 겹치는 상어들을 쫓아내는 함수입니다.

### SmellsTimeSpend
시간을 1초 흐르게 하는 함수입니다.
퍼져있는 냄새들의 잔여 시간을 1초씩 감소시키고, 잔여 시간이 0이 된 냄새들은 모두 제거합니다.

---


### 문제 7: 양 구출 작전

**문제 난이도**

- Gold 3

**문제 유형**

- DFS
- Tree

 **접근 방식 및 풀이**

저는 `늑대가 $a$마리 살고 있다 -> 양이 $-a$마리 살고 있다`로 해석했습니다.

1번 섬, 즉 루트 정점으로 이동하는 것이 목표이기 때문에, DFS를 사용해 각 정점 별로 서브트리에서 양이 올 수 있는 최댓값을 계산해주면 됩니다.

---


### 문제 8: 미로 탈출하기

**문제 난이도**

- Gold 3

**문제 유형**

- DFS

 **접근 방식 및 풀이**

모든 점을 방문할 때까지 DFS를 돌리며, 만약 밖으로 나가는 길이 존재했다면 방문 배열에 1을 저장하고, 그렇지 않은 경우에는 -1을 저장하도록 했습니다.

마지막에 1이 저장된 칸의 수를 세주어 해결했습니다.

## Trouble shooting
DFS 중 방문 처리를 할 때, 현재 칸에서 다음 칸 DFS를 마치고 돌아왔을 때, 다음 칸의 정보를 받아오지 못하는 현상이 발생했었습니다.
좌표를 잘못 넣어준 게 문제였습니다.