### PR TITLE
Youskim/week 6

### DIFF
--- a/김유성-6주차/Main12761돌다리
+++ b/김유성-6주차/Main12761돌다리
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int A, B, N, M;
+	static int[] dx;
+	static int[] bridge = new int[100_001];
+	static boolean[] visited = new boolean [100_001];
+
+
+	public static void main(String[] args) throws IOException {
+		init();
+		move();
+		System.out.println(bridge[M]);
+	}
+
+	static void init() throws IOException {
+		Scanner sc = new Scanner(System.in);
+		A = sc.nextInt();
+		B = sc.nextInt();
+		N = sc.nextInt();
+		M = sc.nextInt();
+		
+		dx = new int[] {A, B, -A, -B, 1, -1};
+	}
+
+	static void move() {
+		Queue<Integer> q = new LinkedList<Integer>();
+		
+		int nx = 0;
+		q.add(N);
+		visited[N] = true;
+		
+		while (!q.isEmpty()) {
+			
+			int position = q.poll();
+			if (position == M) {
+				return ;
+			}
+			
+			nx = position * A;
+			if (isMove(nx)) {
+				q.add(nx);
+				bridge[nx] = bridge[position] + 1;
+				visited[nx] = true;				
+			}
+			nx = position * B;
+			if (isMove(nx)) {
+				q.add(nx);
+				bridge[nx] = bridge[position] + 1;
+				visited[nx] = true;	
+			}
+			
+			for (int i = 0; i < dx.length; i++) {
+				nx = position + dx[i];
+				if (isMove(nx)) {
+					q.add(nx);
+					bridge[nx] = bridge[position] + 1;
+					visited[nx] = true;
+				}
+			}
+		}
+	}
+	
+	static boolean isMove(int nx) {
+		if (nx >= 0 && nx <= 100_000 && !visited[nx]) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/김유성-6주차/Main2304창고다각형
+++ b/김유성-6주차/Main2304창고다각형
@@ -1,0 +1,63 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N, area = 0, min_L = 1001, max_L = 0;
+	static int[] squar;
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		
+		int max_index = getMaxIndex(min_L, max_L);
+		searchToStart(min_L, max_index);
+		searchToEnd(max_index, max_L);
+		System.out.println(area);
+	}
+
+	static void searchToStart(int start, int end) {
+		int max = 0;
+		for (int i = start; i <= end; i++) {
+			max = Math.max(max, squar[i]);
+			area += max;
+		}
+	}
+
+	static void searchToEnd(int start, int end) {
+		int max = 0;
+		for (int i = end; i > start; i--) {
+			max = Math.max(max, squar[i]);
+			area += max;
+		}
+	}
+
+	static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+		squar = new int[1001];
+
+		for (int i = 1; i <= N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int index = Integer.parseInt(st.nextToken());
+			int value = Integer.parseInt(st.nextToken());
+			squar[index] = value;
+			min_L = Math.min(min_L, index);
+			max_L = Math.max(max_L, index);
+		} 
+	}
+
+	static int getMaxIndex(int start, int end) {
+		int max = 0;
+		int max_index = 0;
+		for(int i = start; i <= end; i++) {
+			if (max < squar[i]) {
+				max = squar[i];
+				max_index = i;
+			}
+		}
+		return max_index;
+	}
+}

--- a/김유성-6주차/Main2473세용액
+++ b/김유성-6주차/Main2473세용액
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N;
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static int[] liquid;
+	static int[] ret = new int[3];
+	static long min;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		getMin();
+		System.out.println(ret[0] + " " + ret[1] + " " + ret[2]);
+	}
+
+	static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+		liquid = new int[N];
+
+		st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < N; i++) {
+			liquid[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(liquid);
+		min = 3_000_000_000L;
+	}
+
+	static void getMin() {
+		for (int i = 0; i < N - 2; i++) {
+			int start = i + 1, end = N - 1;
+			while (start < end) {
+				long now = (long)liquid[i] + (long)liquid[start] + (long)liquid[end]; 
+				if (now < 0) {
+					if (Math.abs(now) < Math.abs(min)) {
+						min = now;
+						ret[0] = liquid[i]; ret[1] = liquid[start]; ret[2] = liquid[end];
+					}
+					start += 1;
+				} else {
+					if (Math.abs(now) < Math.abs(min)) {
+						min = now;
+						ret[0] = liquid[i]; ret[1] = liquid[start]; ret[2] = liquid[end];
+					}
+					end -= 1;
+				}
+			}
+		}
+	}
+}

--- a/김유성-6주차/Main2631줄세우기
+++ b/김유성-6주차/Main2631줄세우기
@@ -1,0 +1,46 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	
+	static int N, max;
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static int[] child;
+	static int[] dp;
+	
+	
+	public static void main(String[] args) throws IOException {
+		init();
+		dp();
+		System.out.println(N - max);
+	}
+	
+	static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+		
+		child = new int [N + 1];
+		dp = new int [N + 1];
+		
+		for (int i = 1; i <= N; i++) {
+			child[i] = Integer.parseInt(br.readLine());
+		}
+		max = 0;
+	}
+	
+	static void dp() {
+		dp[1] = 1;
+		
+		for (int i = 2; i <= N; i++) {
+			dp[i] = 1;
+			for (int j = 1; j < i; j++) {
+				if (child[j] < child[i]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+				}
+			}
+			max = Math.max(max, dp[i]);
+		}
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 6주차 [김유성] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **줄세우기**
  - [x] **세 용액**  
  - [x] **창고 다각형**
  - [ ] **사전 순 최대 공통 부분 수열**  
  - [x] **돌다리**  

---

## 💡 풀이 방법
### 문제 1: 줄세우기
(문제 이름은 현재 문제에 맞게 바꿔주세요! 바꾸시고 이 문장을 지워주세요.)

**문제 난이도**
- 골드 4

**문제 유형**
- DP

 **접근 방식 및 풀이**
아이들의 순서가 주어졌을 때, 최소한으로 옮기게 하려면, 정렬되어있는 아이들을 제외한 나머지를 옮겨주어야 합니다.
그래서 dp를 이용해서 1번째 아이부터 N번째 아이까지 확인하면서 최장 증가 부분 수열을 구합니다.
증가하는 순서로 있는 아이들이 가장 많은 값을 구합니다. (이 때, max를 각 loop마다 갱신해줍니다.)
그리고 N에서 그만큼을 빼주면 됩니다.

   
---



### 문제 2: 세 용액
**문제 난이도**
- 골드 3


**문제 유형**
- 정렬, 이분 탐색, 두 포인터


 **접근 방식 및 풀이**
처음에는 3가지 용액 중에서 1,2개를 이중 for문을 통해서 선택해 줍니다. 이 때, 3번째 용액의 범위를 정하기 애매해서
1번째 용액은 처음부터, 2번째 용액은 맨 뒤부터 이분탐색하면서 범위를 좁혀주었습니다. 이를 start, end로 지정해서 합했을 때
가장 값이 작은 값을 구했습니다. => fail

그래서 처음 값만 선택을 해주고, 그 다음 값과 맨 마지막 값을 start, end롤 지정해주고 이분탐색이 아니라 투 포인터를 사용해서 탐색했습니다.
그리고 현재 3용액의 합이 0보다 작으면 min에 저장해놓은 절대값과 비교해서 min의 절대값이 더 크면 start를 증가시켜서 
오른쪽으로 이동해서 더 큰 값을 합치도록 해주고, 0보다 클 때 min의 절대값과 비교해서 작으면 end를 감소시켜서
왼쪽으로 이동하면서 확인해 주었습니다.

---
### 문제 3: 창고 다각형
**문제 난이도**
- 실버 2


**문제 유형**
- 구현, 자료 구조, 브루트포스 ,스택

 **접근 방식 및 풀이**
이 문제는 가장 꼭대기를 기준으로 오른쪽과 왼쪽으로 나누어서 각각 끝에서부터 꼭대기까지 올라가면서
max값을 갱신해주면서 올라가는 중에 가장 큰 면적만큼 더해주면서 값을 구해주었습니다.
이 때, 제일 처음과 끝은 처음 input을 받을 때 저장해주어서 탐색범위를 줄여주었습니다.


---
### 문제 4: 사전 순 최대 공통 부분 수열
**문제 난이도**
- 골드 4


**문제 유형**
- 그리디 알고리즘


 **접근 방식 및 풀이**
풀이 실패..
   
---
### 문제 5: 돌다
**문제 난이도**
- 실버 1


**문제 유형**
- 그래프 이론, 그래프 탐색, BFS


 **접근 방식 및 풀이**
BFS를 사용해서 현재 위치에서 이동 가능한 곳을 저장해주면서 돌다리 배열의 값을 채워줍니다. 그러다가
M을 만나면 종료할 수 있도록한 후 값을 출력해주었습니다.
   