### PR TITLE
Ybg6539/week 7

### DIFF
--- a/유병규_7주차/[BOJ-12026] BOJ 거리.java
+++ b/유병규_7주차/[BOJ-12026] BOJ 거리.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        String line = br.readLine();
+        int[] dp = new int[line.length()+1];
+        
+        for(int i=2; i<=n; i++) {
+        	if(line.charAt(i-1) == 'B') {
+        		int min = Integer.MAX_VALUE;
+        		for(int j=1; j<i; j++) {
+        			if(line.charAt(j-1) != 'J' || dp[j] == -1) continue;
+        			min = Math.min(min, dp[j]+((i-j)*(i-j)));
+        		}
+        		dp[i] = min==Integer.MAX_VALUE ? -1 : min;
+        	}
+        	
+        	else if(line.charAt(i-1) == 'O') {
+        		int min = Integer.MAX_VALUE;
+        		for(int j=1; j<i; j++) {
+        			if(line.charAt(j-1) != 'B' || dp[j] == -1) continue;
+        			min = Math.min(min, dp[j]+((i-j)*(i-j)));
+        		}
+        		dp[i] = min==Integer.MAX_VALUE ? -1 : min;
+        	}
+        	
+        	else{
+        		int min = Integer.MAX_VALUE;
+        		for(int j=1; j<i; j++) {
+        			if(line.charAt(j-1) != 'O' || dp[j] == -1) continue;
+        			min = Math.min(min, dp[j]+((i-j)*(i-j)));
+        		}
+        		dp[i] = min==Integer.MAX_VALUE ? -1 : min;
+        	}
+        }
+        
+//        System.out.println(Arrays.toString(dp));
+        System.out.println(dp[n]);
+    }
+}

--- a/유병규_7주차/[BOJ-16564] 히오스 프로게이머.java
+++ b/유병규_7주차/[BOJ-16564] 히오스 프로게이머.java
@@ -1,0 +1,43 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	public static void main(String[] args) throws IOException{
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		int n = Integer.parseInt(st.nextToken());
+		int k = Integer.parseInt(st.nextToken());
+		
+		
+		int[] numbers = new int[n];
+		for(int i=0; i<n; i++) {
+			numbers[i] = Integer.parseInt(br.readLine());
+		}
+		
+		if(n == 1) {
+			System.out.println(numbers[0]+k);
+			return;
+		}
+		int result = 0;
+		Arrays.sort(numbers);
+		int left = numbers[0];
+		int right = numbers[0]+k;
+		while(left <= right) {
+			int mid = (left+right)/2;
+			
+			long need = 0;
+			for(int i=0; i<numbers.length; i++) {
+				if(mid <= numbers[i]) break;
+				need += mid-numbers[i];
+			}
+			
+			if(need <= k) {
+				left = mid+1;
+				result = Math.max(result, mid);
+			}
+			else right = mid-1;
+		}
+		System.out.println(result);
+	}
+}

--- a/유병규_7주차/[BOJ-16918] 봄버맨.java
+++ b/유병규_7주차/[BOJ-16918] 봄버맨.java
@@ -1,0 +1,77 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int r, c;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        r = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+        
+        char[][] originMap = new char[r][c];
+        for(int i=0; i<r; i++) {
+        	String line = br.readLine();
+        	for(int j=0; j<c; j++) {
+        		originMap[i][j] = line.charAt(j);
+        	}
+        }
+        
+        char[][] fullMap = new char[r][c];
+        char[][] map1 = new char[r][c];
+        char[][] map2 = new char[r][c];
+        for(int i=0; i<r; i++) {
+        	Arrays.fill(fullMap[i], 'O');
+        	Arrays.fill(map1[i], 'O');
+        	Arrays.fill(map2[i], 'O');
+        }
+        
+        int[][] d = {{-1,0},{0,1},{1,0},{0,-1}};
+        for(int i=0; i<r; i++) {
+        	for(int j=0; j<c; j++) {
+        		if(originMap[i][j] == 'O') {
+        			map1[i][j] = '.';
+        			for(int index=0; index<4; index++) {
+        				int nx = i+d[index][0];
+        				int ny = j+d[index][1];
+        				if(nx<0 || nx>=r || ny<0 || ny>=c) continue;
+        				map1[nx][ny] = '.';
+        			}
+        		}
+        	}
+        }
+        
+        for(int i=0; i<r; i++) {
+        	for(int j=0; j<c; j++) {
+        		if(map1[i][j] == 'O') {
+        			map2[i][j] = '.';
+        			for(int index=0; index<4; index++) {
+        				int nx = i+d[index][0];
+        				int ny = j+d[index][1];
+        				if(nx<0 || nx>=r || ny<0 || ny>=c) continue;
+        				map2[nx][ny] = '.';
+        			}
+        		}
+        	}
+        }
+        //1:그대로 2:꽉 3:반전 4:꽉 5:그대로 6:꽉 7:반전 8:꽉...
+        if(n == 1) print(originMap); 
+        else if(n%2 == 0) print(fullMap);
+        else if(n%4 == 3) print(map1);
+        else if(n%4 == 1) print(map2);
+    }
+
+	private static void print(char[][] map) {
+		StringBuilder sb = new StringBuilder();
+		for(int i=0; i<r; i++) {
+			for(int j=0; j<c; j++) {
+				sb.append(map[i][j]+"");
+			}
+			sb.append("\n");
+		}
+		System.out.println(sb.toString().trim());
+	}
+}

--- a/유병규_7주차/[BOJ-16974] 레벨 햄버거.java
+++ b/유병규_7주차/[BOJ-16974] 레벨 햄버거.java
@@ -1,0 +1,39 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static long[] lengths;
+	private static long[] pattys;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        long x = Long.parseLong(st.nextToken());
+        
+        lengths = new long[n+1];
+        pattys = new long[n+1];
+        lengths[0] = 1;
+        pattys[0] = 1;
+        for(int i=1; i<=n; i++) {
+        	lengths[i] = (lengths[i-1]*2) + 3;
+        	pattys[i] = (pattys[i-1]*2) + 1;
+        }
+        
+        long result = counting(n, x);
+        
+        System.out.println(result);
+    }
+
+	private static long counting(int level, long x) {
+		if(level == 0) return 1;
+		if(x == 1) return 0;
+		if(x == lengths[level]) return pattys[level];
+		
+		long mid = (lengths[level]/2) + 1;
+		if(x == mid) return pattys[level-1] + 1;
+		if(x < mid) return counting(level-1, x-1);
+		return pattys[level-1] + 1 + counting(level-1, x-mid);
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 7주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [ ]  **서울 지하철 2호선**
- [x]  **BOJ 거리**
- [x]  **레벨 햄버거**
- [x]  **히오스 프로게이머**
- [x]  **봄버맨**

---

- [ ]  **문제**
- [ ]  **문제**

---

## 💡 풀이 방법

### 문제 1: 서울 지하철 2호선

**문제 난이도**

- 골드 4

**문제 유형**

- DP, 문자열

**접근 방식 및 풀이**

-

---

### 문제 2: BOJ 거리

**문제 난이도**

- 실버 1

**문제 유형**

- DP

**접근 방식 및 풀이**

- 처음에는 사용하는 에너지가 제곱수로 늘어나기 때문에 단순히 가장 가까운 블록으로 이동하는 그리디 방식을 생각했습니다. 하지만 그리디 방법은 최적의 해를 구하는 방식이 아니었고, BOJ 규칙으로 현재 상태가 이전 상태에 의존하고 일정한 규칙이 반복되어 DP로 접근하였습니다.
- dp[n]은 n번째 블록까지 오는 최소 에너지 양으로, dp[i]는 주어진 문자열에서 i번째 값에 따라 i번째 블록에 올 수 있는 경우의 수 중 최솟값을 저장하는 것으로 문제를 해결하였습니다.

---

### 문제 3: 레벨 햄버거

**문제 난이도**

- 골드 5

**문제 유형**

- 분할 정복, DP, 재귀

**접근 방식 및 풀이**

- 햄버거를 만드는 규칙은 다음과 같습니다.(H = hamberger)
    - $H_i = Bun + (H_{i-1}) + Patty + (H_{i-1}) + Bun$
- 이에 따른 각 레벨 별 햄버거의 총 길이와 패티의 개수는 다음과 같습니다.(L = length, P = patty)
    - $L_i = (L_{i-1}*2)+3$, $P_i = (P_{i-1}*2)+1$
- X의 위치가 햄버거의 가운데 위치를 기준으로 왼쪽 또는 오른쪽 또는 동일한 위치에 있을 경우를 나눠 재귀를 통해 문제를 해결하였습니다.

---

### 문제 4: 히오스 프로게이머

**문제 난이도**

- 실버 1

**문제 유형**

- 이분 탐색

**접근 방식 및 풀이**

- 레벨 목표값을 임의로 설정한 다음 해당 값의 위치를 이분 탐색으로 확인합니다. 그리고 그 아래에 있는 레벨들을 목표값으로 만들기 위해 필요한 양을 계산하여 문제를 해결하였습니다.
- 필요한 양을 계산할 때 int범위를 벗어날 수 있어 long으로 설정하였으며 기존 레벨 중 최솟값을 최대로 만드는 것이 목표이기 때문에 목표값 설정의 범위를 추가 레벨업(K)을 기존 레벨 중 최솟값에 전부 주는 것과 주지 않는 것으로 설정하여 정렬 후 `numbers[0]\~numbers[0]+k`로 설정하였습니다.

---

### 문제 5: 봄버 

**문제 난이도**

- 

**문제 유형**

- 

**접근 방식 및 풀이**

- 입력 받은 map을 1번, 전부 폭탄을 채운 map을 2번, 1번의 폭탄이 터진 map을 3번으로 설정하여 1부터 시작하여 2 → 3 → 2 → 1 순으로 반복한다고 생각하고 문제를 풀었습니다. 하지만 3번이 터진 map을 4번으로 설정하여 1부터 시작하여 2 → 3 → 2 → 4 순으로 반복한다는 것을 깨닫고 문제를 해결하였습니다. 힌트를 보고 단순하게 생각한 것이 실수였던 것 같습니다.

---