### PR TITLE
[김유성-7주차 알고리즘 스터디]

### DIFF
--- a/김유성-7주차/Main12026_BOJ_거리
+++ b/김유성-7주차/Main12026_BOJ_거리
@@ -1,0 +1,59 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N;
+	static int[] dp;
+	static String input;
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		solve();
+		System.out.println(dp[N]);
+	}
+	
+	static void solve() {
+		dp[1] = 0;
+		for (int i = 1; i <= N - 1; i++) {
+			char prev = input.charAt(i - 1);
+			if (dp[i] == -1)
+				continue;
+			
+			for (int j = i + 1; j <= N; j++) {
+				char next = input.charAt(j - 1);
+				
+				if (prev == 'B' && next == 'O') {
+					if (dp[j] == -1)
+						dp[j] = dp[i] + (j - i) * (j - i);
+					else
+						dp[j] = Math.min(dp[j], dp[i] + (j - i) * (j - i));
+					 
+				} else if (prev == 'O' && next == 'J') {
+					if (dp[j] == -1)
+						dp[j] = dp[i] + (j - i) * (j - i);
+					else
+						dp[j] = Math.min(dp[j], dp[i] + (j - i) * (j - i));
+					
+				} else if (prev == 'J' && next == 'B') {
+					if (dp[j] == -1)
+						dp[j] = dp[i] + (j - i) * (j - i);
+					else
+						dp[j] = Math.min(dp[j], dp[i] + (j - i) * (j - i));
+				}
+			}
+		}
+	}
+
+	static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+		dp = new int [N + 1];
+		Arrays.fill(dp, -1);
+		input = br.readLine();
+	}
+}

--- a/김유성-7주차/Main16564_히오스_프로게이머
+++ b/김유성-7주차/Main16564_히오스_프로게이머
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N, K, level[], max;
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		getLevel();
+		System.out.println(max);
+	}
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+		
+		level = new int [N];
+		max = 0;
+		
+		for (int i = 0; i < N; i++) {
+			level[i] = Integer.parseInt(br.readLine());
+		}
+		Arrays.sort(level);
+	}
+	
+	static void getLevel() {
+		int start = level[0], end = level[N - 1], mid;
+		while (start <= end) {
+			mid = (start + end) / 2;
+			
+			long result = 0;
+			for (int i = 0; i < N; i++) {
+				if (level[i] < mid) {
+					result += (mid - level[i]);
+				}
+				if (result > K)
+					break;
+			}
+			
+			if (result <= K) {
+				max = mid;
+				start = mid + 1;
+			} else {
+				end = mid - 1;
+			}
+		}
+	}
+}

--- a/김유성-7주차/Main16947서울지하철_2호선
+++ b/김유성-7주차/Main16947서울지하철_2호선
@@ -1,0 +1,87 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+	static int N;
+	static List<Integer>[] subway;
+	static boolean[] visited, cycle;
+	static int[] distance;
+	static Queue<Integer> q = new LinkedList<>();
+	
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		for (int i = 1; i <= N; i++) {
+			visited = new boolean[N + 1];
+			circleCheck(i, i, 1);
+		}
+		
+		for (int i = 1; i <= N; i++) {
+			if (cycle[i])
+				q.add(i); // 사이클에 속한 노드들은 큐에 저장
+			else
+				distance[i] = -1; // 나머지 노드들의 거리는 -1로 초기화
+		}
+		
+		bfs();
+		
+		StringBuilder sb = new StringBuilder("");
+		for (int i = 1; i <= N; i++) {
+			sb.append(distance[i] + " ");
+		}
+		System.out.println(sb);
+	}
+
+	static void init() throws IOException {
+		N = Integer.parseInt(br.readLine());
+		
+		subway = new ArrayList[N + 1];
+		cycle = new boolean[N + 1];
+		distance = new int [N + 1];
+		
+		for (int i = 1; i <= N; i++)
+			subway[i] = new ArrayList<>();
+		
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int a = Integer.parseInt(st.nextToken());
+			int b = Integer.parseInt(st.nextToken());
+			subway[a].add(b);
+			subway[b].add(a);
+		}
+	}
+	
+	static void bfs() {
+		// cycle에 속한 노드들부터 인접한 노드들을 탐색해 나가면서 거리를 1씩 증가시킨다.
+		while (!q.isEmpty()) {
+			int cur = q.poll();
+			for (int next: subway[cur]) {
+				if (distance[next] == -1) { // cycle에 속하지 않았으면서 처음 방문이면
+					distance[next] = distance[cur] + 1;
+					q.add(next);
+				}
+			}
+		}
+	}
+	
+	static void circleCheck(int start, int cur, int cnt) {
+		visited[cur] = true;
+		
+		for (int next: subway[cur]) {
+			if (!visited[next])
+				circleCheck(start, next, cnt + 1);
+			else if (next == start && cnt >= 3) { // 시작점과 같은 노드. cnt가 3이상이면 사이클(2라면 직전 노드로 다시 가는 것일 수 있다)
+				cycle[next] = true;
+			}
+		}
+	}
+	
+}

--- a/김유성-7주차/Main16974레벨_햄버거
+++ b/김유성-7주차/Main16974레벨_햄버거
@@ -1,0 +1,62 @@
+import java.util.Scanner;
+
+public class Main {
+	static int N;
+	static long X, patty = 1L, dp_b[], dp_p[];
+
+	public static void main(String[] args) {
+		init();
+		getEnd();
+		patty = dp_p[N];
+		getBugger(N);
+		System.out.println(patty);
+	}
+
+	static void init(){
+		Scanner sc = new Scanner(System.in);
+		N = sc.nextInt();
+		X = sc.nextLong();
+		dp_b = new long [N + 1];
+		dp_p = new long [N + 1];
+	}
+	
+	static void getEnd() {
+		int n = 1;
+		dp_b[0] = 1;
+		dp_p[0] = 1;
+		while (n <= N) {
+			dp_b[n] = dp_b[n - 1] * 2 + 3;
+			dp_p[n] = dp_p[n - 1] * 2 + 1;
+			n++;
+		}
+	}
+	
+	// bN * 2 + 3이 총 레이어 개수
+	static void getBugger(int n) {
+		if (n == 0)
+			return;
+		
+		long start = 1, end = dp_b[n];
+		long mid = (start + end) / 2;
+		
+		if (X == start) {
+			patty -= dp_p[n];
+			return;
+		} else if (X == end) {
+			return;
+		}
+		
+		if (X == mid) {
+			patty -= dp_p[n - 1];
+			return;
+		} else if (X < mid) {
+			patty -= (dp_p[n - 1] + 1);
+			X -= 1;
+			getBugger(n - 1);
+		} else {
+			X -= mid;
+			getBugger(n - 1);
+		}
+		
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 7주차 [김유성] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **서울 지하철 2호선**
  - [x] **BOJ 거리**  
  - [x] **레벨 햄버거**
  - [x] **히오스 프로게이머**  
  - [ ] **봄버맨**  

---

## 💡 풀이 방법
### 문제 1: 서울 지하철 2호선
(문제 이름은 현재 문제에 맞게 바꿔주세요! 바꾸시고 이 문장을 지워주세요.)

**문제 난이도**
골드 3


**문제 유형**
그래프 이론, 그래프 탐색, BFS, DFS


 **접근 방식 및 풀이**
순환선을 확인할 때는 DFS를, 순환선을 확인하고 나서 거리를 구할 때는 BFS를 쓰면 될 것 같다는 생각은 했는데
코드로 옮길 아이디어가 떠오르지 않아서 풀이를 참고해서 풀었습니다.
먼저 dfs를 이용해서 순환선인지를 찾습니다. 인자로는 시작노드 번호, 현재 노드 번호, 노드를 이동한 횟수를 전달합니다.
노드를 이동한 횟수가 3이상일 때(이전에서 돌아온 것이 아닌 경우) 순환하여 온 것이기 때문에 해당 번호를 true처리해 줍니다.
순환선 처리가 끝났으면 순환선에 속한 노드부터 인접한 노드를 탐색해 나가면서 거리를 1씩 증가시켜 distance배열에
저장해주는 방식으로 구현했습니다.
   
---

### 문제 2: BOJ 거리 
**문제 난이도**
실버 1


**문제 유형**
DP


 **접근 방식 및 풀이**
먼저, dp배열을 -1로 초기화 해주었습니다.
이중for문을 통해서 전체의 경우를 탐색합니다. 어차피 해당 칸에서 다른 칸으로 이동하는 경우가 끝이기 때문에
이렇게 생각했습니다.
전체의 경우를 탐색할 때, B이면 O에 해당하는 경우, O면 J에 해당하는 경우, J면 B에 해당하는 경우를 조건으로 해서
dp배열의 값을 채워주었습니다.
처음에는 단순히 이 경우만 나누어 주었고, 이 전에 방문한 곳인지를 확인해주지 않아서 답이 이상하게 나왔습니다.
그래서 dp[i]가 -1이 아닌 경우, 즉 BOJ순서로 했을 때 그 위치에 도달할 수 있는 경우에만 확인을 해주었습니다.


---
### 문제 3: 레벨 햄버거
**문제 난이도**
골드 5


**문제 유형**
분할 정복, dp

 **접근 방식 및 풀이**
dp를 패티의 갯수와 총 레이어의 갯수 2개로 나누어서 풀었습니다.
이분 탐색처럼 start, end를 기준으로 해서 X값이 mid의 왼쪽이면 오른쪽에 해당하는 만큼 패티의 개수를 빼주고
mid의 오른쪽이면 X값을 재조정 하는 방식으로 풀었습니다.

---
### 문제 4: 히오스 프로게이머
**문제 난이도**
실버 1

**문제 유형**
이분 탐색, 매개 변수 탐색

 **접근 방식 및 풀이**
이전에 풀었던 과자 나눠주기와 비슷한 문제라고 생각하고 같은 방식으로 풀었습니다.
레벨배열을 정렬한 후, 최솟값과 최댓값을 기준으로 해서 이분 탐색 하면서
전체 팀 레벨이 해당 레벨에 도달하기 위해 필요한 총 합을 구한 후, 이 값이 K보다 작을 경우에는 start = mid  + 1로
클 경우에는 end = mid - 1로 하면서 max값을 갱신해주었습니다.

풀이 방식이나 접근 방식에는 문제가 없다고 생각하는데 67%에서 fail처리가 났습니다.
다른 사람들의 풀이도 비교해봤는데 다른 부분이 없다고 생각하는데 혹시 리뷰 중에 잘못된 것 같은 부분이 있다면
코멘트 부탁드립니다!


---
### 문제 5: 문제 이름 
**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

