### PR TITLE
[BOJ-20166] 문자열 지옥에 빠진 호석.java

### DIFF
--- a/권혁준_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.java
+++ b/권혁준_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.java
@@ -1,0 +1,108 @@
+import java.util.*;
+import java.io.*;
+
+
+class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st;
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static int nextInt() {return Integer.parseInt(st.nextToken());}
+	static long nextLong() {return Long.parseLong(st.nextToken());}
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+
+	static int N, M, K, T, ans = 0;
+	static char[][] A;
+	static int[][][][][] dp;
+	static int[] dx = {1,1,1,0,0,-1,-1,-1};
+	static int[] dy = {1,0,-1,1,-1,1,0,-1};
+	static String s;
+	
+	public static void main(String[] args) throws Exception {
+			
+		ready();
+		solve();
+	
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		nextLine();
+		N = nextInt();
+		M = nextInt();
+		K = nextInt();
+		A = new char[N][M];
+		for(int i=0;i<N;i++) A[i] = br.readLine().toCharArray();
+		
+	}
+	
+	static void solve() throws Exception{
+		
+		constructDP();
+		while(K-->0) {
+			s = br.readLine();
+			T = s.length();
+			ans = 0;
+
+			int a = s.length() > 1 ? s.charAt(1)-'a'+1 : 0;
+			int b = s.length() > 2 ? s.charAt(2)-'a'+1 : 0;
+			int c = s.length() > 3 ? s.charAt(3)-'a'+1 : 0;
+			int d = s.length() > 4 ? s.charAt(4)-'a'+1 : 0;
+			
+			if(T <= 4) {
+				for(int i=0;i<N;i++) for(int j=0;j<M;j++) if(A[i][j] == s.charAt(0)) {
+					ans += dp[i][j][a][b][c];
+				}
+			}
+			else {
+				for(int i=0;i<N;i++) for(int j=0;j<M;j++) if(A[i][j] == s.charAt(0)){
+					for(int k=0;k<8;k++) {
+						int x = i+dx[k], y = j+dy[k];
+						x = (x+N)%N;
+						y = (y+M)%M;
+						if(A[x][y] == s.charAt(1)) ans += dp[x][y][b][c][d];
+					}
+				}
+			}
+			
+			bw.write(ans + "\n");
+		}
+		
+	}
+	
+	static void constructDP() {
+		
+		dp = new int[N][M][27][27][27];
+		
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) dp[i][j][0][0][0] = 1;
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) for(int k=0;k<8;k++) {
+			int x = i+dx[k], y = j+dy[k];
+			x = (x+N)%N;
+			y = (y+M)%M;
+			dp[i][j][A[x][y]-'a'+1][0][0] += dp[x][y][0][0][0];
+		}
+		
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) for(int k=0;k<8;k++) {
+			int x = i+dx[k], y = j+dy[k];
+			x = (x+N)%N;
+			y = (y+M)%M;
+			for(int a=1;a<=26;a++) dp[i][j][A[x][y]-'a'+1][a][0] += dp[x][y][a][0][0];
+		}
+		
+		for(int i=0;i<N;i++) for(int j=0;j<M;j++) for(int k=0;k<8;k++) {
+			int x = i+dx[k], y = j+dy[k];
+			x = (x+N)%N;
+			y = (y+M)%M;
+			for(int a=1;a<=26;a++) for(int b=1;b<=26;b++) dp[i][j][A[x][y]-'a'+1][a][b] += dp[x][y][a][b][0];
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 8주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문자열 지옥에 빠진 호석**
  - [ ] **여왕벌**  
  - [ ] **트리**
  - [ ] **거울 설치**  
  - [ ] **경쟁적 전염**  
---
  - [ ] **두 배 더하기**
  - [ ] **회전 초밥**
  - [ ] **소셜 네트워킹 어플리케이션**

---

## 💡 풀이 방법
### 문제 1: 문자열 지옥에 빠진 호석

**문제 난이도**

Gold 4

**문제 유형**

DP

 **접근 방식 및 풀이**

5차원 DP배열을 선언해서 다음과 같이 정의했습니다.
dp[x][y][a][b][c] = "x행 y열에서 출발해서, 다음 문자들로 a, b, c를 지나는 경로의 수"

아직 **고르지 않은 상태**를 추가하기위해, dp 배열은 N * M * 27 * 27 * 27 크기로 선언했습니다.

## Trouble shooting
DFS로 완탐을 돌리면 시간복잡도가 $O(KNM \times 8^4)$라서 통과할 것 같았는데, 시간 초과가 발생했습니다.

---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


### 문제 1: 

**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**



---


