### PR TITLE
[Baekjoon-20166] 문자열 지옥에 빠진 호석

### DIFF
--- a/허민권_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.py
+++ b/허민권_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.py
@@ -1,0 +1,49 @@
+from collections import defaultdict
+import sys
+
+input = sys.stdin.readline
+N, M, K = map(int, input().split())
+
+grid = [list(input().strip()) for _ in range(N)]
+max_length = 5
+precomp = defaultdict(int)
+
+directions = [
+    (0, 1),
+    (-1, 1),
+    (-1, 0),
+    (-1, -1),
+    (0, -1),
+    (1, -1),
+    (1, 0),
+    (1, 1),
+]
+
+
+def dfs(y, x, cur_string):
+    precomp[cur_string] += 1
+
+    if len(cur_string) == max_length:
+        return
+
+    for dy, dx in directions:
+        next_y, next_x = y + dy, x + dx
+        if next_y == N:
+            next_y = 0
+        if next_y == -1:
+            next_y = N - 1
+        if next_x == M:
+            next_x = 0
+        if next_x == -1:
+            next_x = M - 1
+
+        dfs(next_y, next_x, cur_string + grid[next_y][next_x])
+
+
+for y in range(N):
+    for x in range(M):
+        dfs(y, x, grid[y][x])
+
+for _ in range(K):
+    query = input().rstrip()
+    print(precomp[query])


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 8주차 [허민권] 


## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문자열 지옥에 빠진 호석**
  - [ ] **문제 2**  
  - [ ] **문제 3**
  - [ ] **문제 4**  
  - [ ] **문제 5**  

---

## 💡 풀이 방법
### 문제 1: 문자열 지옥에 빠진 호석


**문제 난이도**
골드 4


**문제 유형**
dp


 **접근 방식 및 풀이**
처음에 dfs + 캐싱으로 접근했는데 시간초과가 발생했습니다.
문자열이 최대 5개까지이므로 맵을 사용해, 미리 모든 경우의수를 뒤져 해당값이 나오도록구현했습니다.
   
---



### 문제 2: 문제 이름 
 **문제 유형**



 **접근 방식 및 풀이**



---
### 문제 3: 문제 이름 
 **문제 유형**






 **접근 방식 및 풀이**


---
### 문제 4: 문제 이름 
 **문제 유형**



 **접근 방식 및 풀이**


---
### 문제 5: 문제 이름 
 **문제 유형**



 **접근 방식 및 풀이**


