### PR TITLE
[유병규-8주차 알고리즘 스터디]

### DIFF
--- a/유병규_8주차/[BOJ-10836] 여왕벌.java
+++ b/유병규_8주차/[BOJ-10836] 여왕벌.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int m = Integer.parseInt(st.nextToken());
+        int n = Integer.parseInt(st.nextToken());
+        
+        int[] numbers = new int[2*m-1];
+        Arrays.fill(numbers, 1);
+        
+        for(int i=0; i<n; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	int count0 = Integer.parseInt(st.nextToken());
+        	int count1 = Integer.parseInt(st.nextToken());
+        	int count2 = Integer.parseInt(st.nextToken());
+        	
+        	int index = 0;
+        	for(int j=0; j<count0; j++) {
+        		numbers[index++] += 0;
+        	}
+        	for(int j=0; j<count1; j++) {
+        		numbers[index++] += 1;
+        	}
+        	for(int j=0; j<count2; j++) {
+        		numbers[index++] += 2;
+        	}
+        }
+        
+        StringBuilder sb = new StringBuilder();
+        for(int i=0; i<m; i++) {
+        	sb.append(numbers[m-1-i]).append(" ");
+        	for(int j=m; j<2*m-1; j++) {
+        		sb.append(numbers[j]).append(" ");
+        	}
+        	sb.append("\n");
+        }
+        System.out.println(sb.toString().trim());
+    }
+}

--- a/유병규_8주차/[BOJ-12931] 두 배 더하기.java
+++ b/유병규_8주차/[BOJ-12931] 두 배 더하기.java
@@ -1,0 +1,39 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        int[] numbers = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i=0; i<n; i++) {
+        	numbers[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        
+        int count = 0;
+        while(true) {
+        	
+        	for(int i=0; i<n; i++) {
+        		if(numbers[i] == 0) continue;
+        		if(numbers[i]%2 == 1) {
+        			numbers[i]--;
+        			count++;
+        		}
+        		numbers[i] /= 2;
+        	}
+        	boolean isAllZero = true;
+        	for(int i=0; i<n; i++) {
+        		if(numbers[i] == 0) continue;
+        		isAllZero = false;
+        		break;
+        	}
+        	if(isAllZero) break;
+        	count++;
+        }
+        System.out.println(count);
+    }
+}

--- a/유병규_8주차/[BOJ-15961] 회전 초밥.java
+++ b/유병규_8주차/[BOJ-15961] 회전 초밥.java
@@ -1,0 +1,42 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int d = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        
+        int[] sushi = new int[n];
+        for(int i=0; i<n; i++) {
+        	sushi[i] = Integer.parseInt(br.readLine());
+        }
+        
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(c, 1);
+        
+        for(int i=0; i<k; i++) {
+        	map.put(sushi[i], map.getOrDefault(sushi[i], 0)+1);
+        }
+        
+        int max = Math.max(map.size(), 1);
+        int start = 0;
+        int end = k;
+        do {
+        	map.put(sushi[end], map.getOrDefault(sushi[end], 0)+1);
+        	map.put(sushi[start], map.get(sushi[start])-1);
+        	if(map.get(sushi[start]) == 0) map.remove(sushi[start]);
+        	
+        	max = Math.max(map.size(), max);
+        	start = (start+1)%n;
+        	end = (end+1)%n;
+        } while(start != 0);
+        
+        System.out.println(max);
+    }
+}

--- a/유병규_8주차/[BOJ-18405] 경쟁적 전염.java
+++ b/유병규_8주차/[BOJ-18405] 경쟁적 전염.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        int[][] map = new int[n+1][n+1];
+        Queue<int[]>[] virus = new LinkedList[k+1];
+        for(int i=1; i<=k; i++) {
+        	virus[i] = new LinkedList<int[]>();
+        }
+        
+        for(int i=1; i<=n; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	for(int j=1; j<=n; j++) {
+        		map[i][j] = Integer.parseInt(st.nextToken());
+        		if(map[i][j] == 0) continue;
+        		virus[map[i][j]].offer(new int[] {i,j});
+        	}
+        }
+        
+        st = new StringTokenizer(br.readLine());
+        int s = Integer.parseInt(st.nextToken());
+        int[] target = {Integer.parseInt(st.nextToken()), Integer.parseInt(st.nextToken())};
+        
+        if(map[target[0]][target[1]] != 0) {
+        	System.out.println(map[target[0]][target[1]]);
+        	return;
+        }
+        
+        int[][] d = {{-1,0},{0,1},{1,0},{0,-1}};
+        int time = 0;
+        while(time < s) {
+        	for(int i=1; i<=k; i++) {
+        		int size = virus[i].size();
+        		for(int j=0; j<size; j++) {
+        			int[] point = virus[i].poll();
+        			for(int index=0; index<d.length; index++) {
+        				int nx = point[0] + d[index][0];
+        				int ny = point[1] + d[index][1];
+        				if(nx<=0 || nx>n || ny<=0 || ny>n || map[nx][ny] != 0) continue;
+        				if(nx == target[0] && ny == target[1]) {
+        					System.out.println(i);
+        					return;
+        				}
+        				map[nx][ny] = i;
+        				virus[i].offer(new int[] {nx,ny});
+        			}
+        		}
+        	}
+        	time++;
+        }
+        
+        System.out.println(0);
+    }
+}

--- a/유병규_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.java
+++ b/유병규_8주차/[BOJ-20166] 문자열 지옥에 빠진 호석.java
@@ -1,0 +1,66 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int count=0;
+	private static int[][] d = {{-1,0},{-1,1},{0,1},{1,1},{1,0},{1,-1},{0,-1},{-1,-1}};
+	private static int n,m;
+	private static char[][] map;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        map = new char[n][m];
+        for(int i=0; i<n; i++) {
+        	String line = br.readLine();
+        	for(int j=0; j<m; j++) {
+        		map[i][j] = line.charAt(j);
+        	}
+        }
+        
+        Map<String, Integer> hashmap = new HashMap<>();
+        StringBuilder sb = new StringBuilder();
+        for(int repeat=0; repeat<k; repeat++) {
+        	String word = br.readLine();
+        	count=0;
+        	if(hashmap.containsKey(word)) {
+        		sb.append(hashmap.get(word)).append("\n");
+        		continue;
+        	}
+        	for(int i=0; i<n; i++) {
+        		for(int j=0; j<m; j++) {
+        			if(map[i][j] != word.charAt(0)) continue;
+        			dfs(i,j,1,word);
+        		}
+        	}
+        	hashmap.put(word, count);
+        	sb.append(count).append("\n");
+        }
+        
+        System.out.println(sb.toString().trim());
+    }
+
+	private static void dfs(int x, int y, int index, String word) {
+		if(index == word.length()) {
+			count++;
+			return;
+		}
+		
+		for(int i=0; i<d.length; i++) {
+			int nx = x+d[i][0];
+			int ny = y+d[i][1];
+			if(nx<0) nx = n-1;
+			if(nx>=n) nx=0;
+			if(ny<0) ny=m-1;
+			if(ny>=m) ny=0;
+			
+			if(word.charAt(index) != map[nx][ny]) continue;
+			dfs(nx, ny, index+1, word);
+		}
+	}
+}

--- a/유병규_8주차/[BOJ-2151] 거울 설치.java
+++ b/유병규_8주차/[BOJ-2151] 거울 설치.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        
+        int[] start = null, end = null;
+        
+        char[][] map = new char[n][n];
+        for(int i=0; i<n; i++) {
+        	String line = br.readLine();
+        	for(int j=0; j<n; j++) {
+        		map[i][j] = line.charAt(j);
+        		if(map[i][j] == '#') {
+        			if(start == null) start = new int[] {i,j};
+        			else end = new int[] {i,j};
+        		}
+        	}
+        }
+        
+        int[][] d = {{-1,0},{0,1},{1,0},{0,-1}};
+        boolean[][][] visited = new boolean[n][n][4];
+        
+        //int [x좌표, y좌표, 방향, 거울개수]
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1,o2) -> o1[3] - o2[3]);
+        
+        //어느 방향이 시작인지 모르니까 일단 다 넣기
+        for(int i=0; i<4; i++) {
+        	pq.offer(new int[] {start[0], start[1], i, 0});
+        }
+        
+        while(!pq.isEmpty()) {
+        	int[] current = pq.poll();
+        	
+        	int x = current[0];
+        	int y = current[1];
+        	int dir = current[2];
+        	int count = current[3];
+        	
+        	visited[x][y][dir] = true;
+        	
+        	if(x == end[0] && y == end[1]) {
+        		System.out.println(count);
+        		return;
+        	}
+        	
+        	int nx = x + d[dir][0];
+        	int ny = y + d[dir][1];
+        	
+        	if(nx<0 || nx>=n || ny<0 || ny>=n || visited[nx][ny][dir] || map[nx][ny] == '*') continue;
+        	
+        	if(map[nx][ny] == '!') {
+        		// '/' : 0->1, 1->0, 2->3, 3->2
+        		int nd = 0;
+        		if(dir == 0) nd = 1;
+        		else if(dir == 1) nd = 0;
+        		else if(dir == 2) nd = 3;
+        		else nd = 2;
+        		pq.offer(new int[] {nx, ny, nd, count+1});
+        		
+        		// '\' : 0->3, 1->2, 2->1, 3->0
+        		if(dir == 0) nd = 3;
+        		else if(dir == 1) nd = 2;
+        		else if(dir == 2) nd = 1;
+        		else nd = 0;
+        		pq.offer(new int[] {nx, ny, nd, count+1});
+        	}
+        	
+        	pq.offer(new int[] {nx, ny, dir, count});
+        }
+    }
+}

--- a/유병규_8주차/[BOJ-4803] 트리(BFS).java
+++ b/유병규_8주차/[BOJ-4803] 트리(BFS).java
@@ -1,0 +1,69 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static String NO_TREE = "No trees.";
+	private static String ONE_TREE = "There is one tree.";
+	private static String N_TREE_FORMAT = "A forest of %d trees.";
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int testCase = 1;
+        while(true) {
+        	StringTokenizer st = new StringTokenizer(br.readLine());
+        	
+        	int n = Integer.parseInt(st.nextToken());
+        	int m = Integer.parseInt(st.nextToken());
+        	
+        	if(n==0 && m==0) {
+        		System.out.println(sb.toString().trim());
+        		return;
+        	}
+        	
+        	boolean[][] graph = new boolean[n+1][n+1];
+        	for(int i=0; i<m; i++) {
+        		st = new StringTokenizer(br.readLine());
+        		int a = Integer.parseInt(st.nextToken());
+        		int b = Integer.parseInt(st.nextToken());
+        		
+        		graph[a][b] = true;
+        		graph[b][a] = true;
+        	}
+        	
+        	boolean[] visited = new boolean[n+1];
+        	int count = 0;
+        	
+        	Queue<Integer> q = new LinkedList<>();
+        	int[] parent = new int[n+1];
+        	for(int node=1; node<=n; node++) {
+        		if(visited[node]) continue;
+        		boolean isTree = true;
+        		visited[node] = true;
+        		q.offer(node);
+        		while(!q.isEmpty()) {
+        			int current= q.poll();
+        			
+        			for(int i=1; i<=n; i++) {
+        				if(!graph[current][i] || i==parent[current]) continue;
+        				if(visited[i]) {
+        					isTree = false;
+        					continue;
+        				}
+        				visited[i] = true;
+        				parent[i] = current;
+        				q.offer(i);
+        			}
+        		}
+        		if(isTree) count++;
+        	}
+        	
+        	sb.append(String.format("Case %d: ", testCase));
+        	if(count == 0) sb.append(NO_TREE).append("\n");
+        	else if(count == 1) sb.append(ONE_TREE).append("\n");
+        	else sb.append(String.format(N_TREE_FORMAT, count)).append("\n");
+        	
+        	testCase++;
+        }
+    }
+}

--- a/유병규_8주차/[BOJ-4803] 트리(DFS).java
+++ b/유병규_8주차/[BOJ-4803] 트리(DFS).java
@@ -1,0 +1,69 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static String NO_TREE = "No trees.";
+	private static String ONE_TREE = "There is one tree.";
+	private static String N_TREE_FORMAT = "A forest of %d trees.";
+	
+	private static int n, m, count;
+	private static boolean[][] graph;
+	private static boolean[] visited;
+    private static boolean isTree;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int testCase = 1;
+        while(true) {
+        	StringTokenizer st = new StringTokenizer(br.readLine());
+        	
+        	n = Integer.parseInt(st.nextToken());
+        	m = Integer.parseInt(st.nextToken());
+        	
+        	if(n==0 && m==0) {
+        		System.out.println(sb.toString().trim());
+        		return;
+        	}
+        	
+        	graph = new boolean[n+1][n+1];
+        	for(int i=0; i<m; i++) {
+        		st = new StringTokenizer(br.readLine());
+        		int a = Integer.parseInt(st.nextToken());
+        		int b = Integer.parseInt(st.nextToken());
+        		
+        		graph[a][b] = true;
+        		graph[b][a] = true;
+        	}
+        	
+        	visited = new boolean[n+1];
+        	count = 0;
+        	for(int i=1; i<=n; i++) {
+        		if(visited[i]) continue;
+        		isTree = true;
+        		dfs(i, -1);
+        		if(isTree) count++;
+        	}
+        	
+        	sb.append(String.format("Case %d: ", testCase));
+        	if(count == 0) sb.append(NO_TREE).append("\n");
+        	else if(count == 1) sb.append(ONE_TREE).append("\n");
+        	else sb.append(String.format(N_TREE_FORMAT, count)).append("\n");
+        	
+        	testCase++;
+        }
+    }
+
+	private static void dfs(int node, int parent) {
+		visited[node] = true;
+		
+		for(int i=1; i<=n; i++) {
+			if(!graph[node][i] || parent == i) continue;
+			if(visited[i]) {
+				isTree = false;
+				continue;
+			}
+			dfs(i, node);
+		}
+	}
+}

--- a/유병규_8주차/[BOJ-7511] 소셜 네트워킹 어플리케이션.java
+++ b/유병규_8주차/[BOJ-7511] 소셜 네트워킹 어플리케이션.java
@@ -1,0 +1,61 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int n;
+	private static int[] parent;
+	
+    public static void main(String[] args) throws IOException {
+    	BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+    	StringBuilder sb = new StringBuilder();
+    	int repeat = Integer.parseInt(br.readLine());
+    	for(int testCase=1; testCase<=repeat; testCase++) {
+    		sb.append(String.format("Scenario %d:%n", testCase));
+    		
+    		n = Integer.parseInt(br.readLine());
+    		int k = Integer.parseInt(br.readLine());
+    		
+    		parent = new int[n];
+    		for(int i=0; i<n; i++) {
+    			parent[i] = i;
+    		}
+    		
+    		for(int i=0; i<k; i++) {
+    			StringTokenizer st = new StringTokenizer(br.readLine());
+    			int a = Integer.parseInt(st.nextToken());
+    			int b = Integer.parseInt(st.nextToken());
+    			
+    			union(a,b);
+    		}
+    		
+    		int m = Integer.parseInt(br.readLine());
+    		for(int i=0; i<m; i++) {
+    			StringTokenizer st = new StringTokenizer(br.readLine());
+    			int a = Integer.parseInt(st.nextToken());
+    			int b = Integer.parseInt(st.nextToken());
+    			
+    			int result = 0;
+    			if(findRoot(a) == findRoot(b)) result = 1;
+    			sb.append(result).append("\n");
+    		}
+    		sb.append("\n");
+    	}
+    	
+    	System.out.println(sb.toString().trim());
+    }
+
+	private static void union(int a, int b) {
+		a = findRoot(a);
+		b = findRoot(b);
+		
+		if(a != b) {
+			parent[b] = a;
+		}
+	}
+
+	private static int findRoot(int x) {
+		if(parent[x] == x) return x;
+		return parent[x] = findRoot(parent[x]);
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 8주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **문자열 지옥에 빠진 호석**
- [x]  **여왕벌**
- [x]  **트리**
- [x]  **거울 설치**
- [x]  **경쟁적 전염**

---

- [x]  **두 배 더하기**
- [x]  **회전 초밥**
- [x]  **소셜 네트워킹 어플리케이션**

---

## 💡 풀이 방법

### 문제 1: 문자열 지옥에 빠진 호석

**문제 난이도**

- 골드 4

**문제 유형**

- DP, DFS, 자료 구조

**접근 방식 및 풀이**

- DP가 생각나지 않았고 시간 복잡도가 $O(KNM5*8)$이고 각 범위가  $K(≤ 1,000), N,M(≤ 10)$로 크지 않아 DFS로 접근하였습니다.
- 예상과 달리 시간 초과가 났지만, 이때 ‘신이 좋아하는 문자열은 중복될 수 있다’의 조건이 있어 결과 값을 HashMap에 저장해놓고 중복된 값이 입력으로 들어온다면 바로 반환하도록 하여 시간을 단축하여 해결하였습니다.

---

### 문제 2: 여왕벌

**문제 난이도**

- 골드 3

**문제 유형**

- 구현, 시뮬레이션, 누적 합

**접근 방식 및 풀이**

- 이 문제에서 주목했던 조건은 ‘자라는 크기를 순서대로 읽었을 때 감소하지 않는다’라는 조건이었습니다. 이 조건을 통해 규칙을 찾아 해결할 수 있었습니다.
- 날짜 별로 주어지는 정보에 따라 각 칸 별 총 성장 값을 계산한 후 초기 값을 더해주면 해당 칸의 최종 값을 구할 수 있습니다. 초기 값은 1로 고정되어 있기 때문에 성장 값만 계산하여 답을 구했습니다.
- 주어지는 정보에 따라 첫번째 열과 첫번째 행은 주어지는 값을 더해주기만 하면 총 성장 값을 구할 수 있습니다.
- 나머지 칸들은 다음과 같은 규칙을 따라 해당 날의 성장 값을 구할 수 있습니다.
    - 해당 칸 기준 왼쪽 칸, 왼쪽 위 칸, 위 칸 중 해당 날의 성장 값이 가장 큰 값으로 성장합니다. 그리고 주어지는 첫번째 열과 첫번째 행의 자라는 크기는 순서대로 읽었을 때 감소하지 않습니다.
    - 이에 따라 첫번째 열을 제외한 두번째 열~마지막 열까지의 각 칸 값은 각 열의 첫번째 행의 값과 동일합니다.
- 따라서 주어지는 성장 값들만 통해 전체 칸들의 총 성장 값을 구할 수 있었습니다.

---

### 문제 3: 트리

**문제 난이도**

- 골드 4

**문제 유형**

- 트리, DFS, 분리 집합

**접근 방식 및 풀이**

- 트리는 사이클이 없는 연결된 그래프이기 때문에 주어진 그래프가 트리인지 파악하기 위해 DFS의 파라미터로 부모 노드를 넘겨주어 판단하였습니다.
- BFS의 경우 해당 노드의 parent를 저장하는 int배열을 생성한 후 부모 노드가 아닌 이미 방문한 노드와 연결되어 있다면 사이클로 판단하였습니다.

---

### 문제 4: 거울 설치

**문제 난이도**

- 골드 3

**문제 유형**

- BFS, 최단 경로, 다익스트라

**접근 방식 및 풀이**

- 먼저 길 찾기 문제라 생각해 BFS로 접근하였습니다. 이때 최소한의 거울을 설치해야 하기 때문에 길을 찾은 것 중 설치한 거울의 개수가 가장 적은 것을 찾기 위해 큐 대신 사용한 거울 개수를 기준으로 하는 우선순위 큐를 사용하였습니다. 방문처리의 경우 좌표 값에서 4가지 방향으로 접근할 수 있기 때문에 visted[N][N][4]로 초기화하여 사용하였습니다.
- 거울을 설치할 수 있는 곳에서는 다음과 같은 3가지 경우가 나옵니다. 각 경우에서 빛이 들어온 방향에 따라 다음 빛의 동향을 우선순위 큐에 넣으며 문제를 해결하였습니다.
    1. 거울을 ‘/’ 방향으로 설치: `상 → 우`, `하 → 좌`, `좌 → 하`, `우 → 상` 
    2. 거울을 ‘\’ 방향으로 설치: `상 → 좌`, `하 →우`, `좌 → 상`, `우 → 하`
    3. 거울을 설치하지 않음: `방향 그대로`
- 이때 일반적인 BFS와 달리 방문처리를 큐에 넣을 때가 아닌 큐에서 꺼낸 후 방문처리를 진행하였습니다. 그 이유는 우선순위 큐를 사용하였기 때문인데, 만약 큐에 넣을 때 방문처리를 진행한다면 이후 같은 방향이지만 거울 개수가 더 적은 경우가 존재할 경우 이미 해당 방향이 방문처리 되어 이 경우가 처리되지 않게 됩니다. 하지만 꺼낸 후 방문처리를 진행하면 같은 방향이지만 거울 개수가 더 적은 경우도 큐에 들어오고, 거울 개수가 더 적기 때문에 더 먼저 처리되어 최적해를 찾을 수 있게 됩니다.

---

### 문제 5: 경쟁적 전염

**문제 난이도**

- 골드 5

**문제 유형**

- 구현, BFS

**접근 방식 및 풀이**

- 각 바이러스의 위치 값을 Queue 배열에 저장하여 시간 별로 확장되며 만약 확장되는 곳이 찾아야 하는 곳이면 바로 종료되도록 구현하였습니다.
- 찾아야 하는 곳이 시작 시점에 이미 바이러스가 있는 경우라면 바로 리턴하도록 구현하여 문제를 해결하였습니다.

---

### 문제 6: 두 배 더하기

**문제 난이도**

- 골드 5

**문제 유형**

- 그리디

**접근 방식 및 풀이**

- 반대로 주어진 배열을 모두 0으로 만드는 방법을 생각했습니다.
- 각 원소를 순회하며 2로 나눈 나머지가 0이라면 나눠주고, 1이라면 1을 빼고 나눠줍니다. 이때 1을 빼는 것은 ‘값 하나를 1 증가시킨다’이기 때문에 1을 뺄 때마다 `count+1`을 해주고, 2로 나누는 것은 ‘모든 값을 두 배 시킨다’이기 때문에 배열 순회가 끝난 후 `count+1`을 해주었습니다. 그리고 모든 값이 0이면 종료되고 `count`를 출력하도록 구현하여 문제를 해결하였습니다.

---

### 문제 7: 회전 초밥

**문제 난이도**

- 골드 4

**문제 유형**

- 투 포인터, 슬라이딩 윈도우

**접근 방식 및 풀이**

- 주어진 배열에서 연속된 K개만큼 선택했을 때 최대이기 때문에 배열을 만들고 슬라이딩 윈도우로 해결하였습니다. 이때 포함하는 원소의 개수를 파악할 때 원소의 삽입, 삭제, 포함 여부를 빠르게 판단해야 하기 때문에 HashMap을 사용하여 문제를 해결하였습니다.
- 이때 회전초밥이기 때문에 배열 끝까지만 확인하는 것이 아니라 배열의 끝과 시작이 연결된 것으로 가정하고 확인하는 구간이 시작할 때의 구간과 같으면 종료되도록 설정하여 문제를 해결하였습니다.

---

### 문제 8: 소셜 네트워킹 어플리케이션

**문제 난이도**

- 골드 5

**문제 유형**

- 자료 구조, 분리 집합

**접근 방식 및 풀이**

- 처음에는 인접 행렬과 인접 리스트를 사용하여 BFS로 구현하였지만 두 방법 모두 메모리 초과가 났습니다. 그래서 분리 집합을 적용하여 문제를 해결하였습니다
---