### PR TITLE
Youskim/week 8

### DIFF
--- a/김유성-8주차/Main10836여왕벌
+++ b/김유성-8주차/Main10836여왕벌
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static int move[][] = {{-1, 0}, {0, 1}}; // 위, 오른쪽 
+	static int M, N, bug[][], bug_grow[];
+	
+	public static void main(String[] args) throws IOException {
+		init();
+		solve();
+	}
+	
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		M = Integer.parseInt(st.nextToken());
+		N = Integer.parseInt(st.nextToken());
+		
+		bug = new int[M][M];
+		for (int i = 0; i < M; i++)
+			Arrays.fill(bug[i], 1);
+		
+		bug_grow = new int [M + M - 1];
+		
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());			
+			int grow = 0;
+			int input = Integer.parseInt(st.nextToken());
+			int h = M - 1;
+			int w = 0;
+			for (int n = 0; n < M + M - 1; n++) {
+				while (input == 0) {
+					input = Integer.parseInt(st.nextToken());
+					grow++;
+				}
+				bug[h][w] += grow;
+				input--;
+				
+				if (h == 0)
+					w++;
+				else
+					h--;
+			}
+		}
+	}
+	
+	static void solve() {
+		StringBuilder sb = new StringBuilder("");
+		for (int h = 0; h < M; h++) {
+			for (int w = 0; w < M; w++) {
+				if (h > 0 && w > 0) {
+					int max = Math.max(bug[h][w - 1], bug[h - 1][w - 1]);
+					max = Math.max(max, bug[h - 1][w]);
+					bug[h][w] = max;
+				}
+				sb.append(bug[h][w] + " ");
+			}
+			sb.append("\n");
+		}
+		System.out.print(sb.toString());
+	}
+		
+}

--- a/김유성-8주차/Main18405_경쟁적_전염
+++ b/김유성-8주차/Main18405_경쟁적_전염
@@ -1,0 +1,85 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+    
+	static class Virus {
+		int h, w, num;
+
+		public Virus(int h, int w, int num) {
+			this.h = h;
+			this.w = w;
+			this.num = num;
+		}
+	}
+
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	static int N, K, S, X, Y, map[][], move[][] = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+	static List<Virus>[] virus;
+	static Queue<Virus> v = new LinkedList<>();
+
+	public static void main(String[] args) throws IOException {
+		init();
+		bfs();
+		System.out.println(map[X][Y]);
+	}
+
+	static void bfs() {
+		while (S-- > 0) {
+			int n = v.size();
+			while (n-- > 0) {
+				Virus cur_virus = v.poll();
+				int nh, nw;
+				for (int i = 0; i < 4; i++) {
+					nh = cur_virus.h + move[i][0];
+					nw = cur_virus.w + move[i][1];
+					if (nh > 0 && nw > 0 && nh <= N && nw <= N && map[nh][nw] == 0) {
+						map[nh][nw] = cur_virus.num;
+						v.add(new Virus(nh, nw, cur_virus.num));
+					}
+				}
+			}
+		}
+	}
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		map = new int[N + 1][N + 1];
+		virus = new ArrayList[K + 1];
+		for (int i = 1; i <= K; i++) {
+			virus[i] = new ArrayList<>();
+		}
+
+		for (int i = 1; i <= N; i++) {
+			st = new StringTokenizer(br.readLine());
+			for (int j = 1; j <= N; j++) {
+				map[i][j] = Integer.parseInt(st.nextToken());
+				if (map[i][j] != 0) {
+					virus[map[i][j]].add(new Virus(i, j, map[i][j]));
+				}
+			}
+		}
+		st = new StringTokenizer(br.readLine());
+		S = Integer.parseInt(st.nextToken());
+		X = Integer.parseInt(st.nextToken());
+		Y = Integer.parseInt(st.nextToken());
+
+		for (int k = 1; k <= K; k++) {
+			List<Virus> temp = virus[k];
+			for (Virus vv : temp)
+				v.add(vv);
+		}
+	}
+
+}

--- a/김유성-8주차/Main20166_문자열_지옥
+++ b/김유성-8주차/Main20166_문자열_지옥
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	static int N, M, K;
+	static char[][] map;
+	static int[][] move = { { -1, -1 }, { -1, 0 }, { -1, 1 }, { 0, -1 }, { 0, 1 }, { 1, -1 }, { 1, 0 }, { 1, 1 } };
+	static String[] string_arr;
+	static Map<String, Integer> str_memo = new HashMap<>();
+
+	public static void main(String[] args) throws IOException {
+		init();
+		for (int i = 0; i < N; i++) {
+			for (int j = 0; j < M; j++) {
+				makeString(i, j, 1, map[i][j] + "");
+			}
+		}
+		for (int k = 0; k < K; k++) {
+			System.out.println(str_memo.getOrDefault(string_arr[k], 0));
+		}
+	}
+
+	static void makeString(int h, int w, int cnt, String str) {
+		str_memo.put(str, str_memo.getOrDefault(str, 0) + 1);
+
+		if (cnt == 5)
+			return;
+
+		for (int i = 0; i < 8; i++) {
+			int nh = h + move[i][0];
+			int nw = w + move[i][1];
+
+			nh = (nh + N) % N;
+			nw = (nw + M) % M;
+			makeString(nh, nw, cnt + 1, str + map[nh][nw]);
+		}
+
+	}
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		map = new char[N][M];
+		string_arr = new String[K];
+
+		for (int i = 0; i < N; i++) {
+			String line = br.readLine();
+			for (int j = 0; j < M; j++) {
+				map[i][j] = line.charAt(j);
+			}
+		}
+
+		for (int k = 0; k < K; k++) {
+			string_arr[k] = br.readLine();
+		}
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 8주차 [김유성] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **문자열 지옥에 빠진 호석**
  - [x] **여왕벌**  
  - [ ] **트리**
  - [ ] **거울 설치**  
  - [x] **경쟁적 전염**  

---

## 💡 풀이 방법
### 문제 1: 문자열 지옥에 빠진 호석 
(문제 이름은 현재 문제에 맞게 바꿔주세요! 바꾸시고 이 문장을 지워주세요.)

**문제 난이도**
 골드4

**문제 유형**
DP, DFS

 **접근 방식 및 풀이**
1. 처음에는 복잡도를 계산하지 않고 단순하게 문자열을 하나씩 늘려가면서 모든 DFS를 진행했습니다.
당연히 시간초과가 발생했습니다.

2. DP문제인 거를 확인하지 않고 풀어서 DP풀이는 생각도 하지 못했고, 문자열을 만들어서 map에 저장해야겠다고
생각했습니다. 어차피 최대 10 * 10의 칸에서 출발할 것이고 이 모든칸에서 시작해서 만들 수 있는 1~5자리 문자열의 수는
최대 (8^0 + 8^1 + 8^2 + 8^3 + 8^4) * 100 = 468,100가지가 됩니다.
그래서 dfs를 딱 1번만 돌아서 각 자리에서 출발해서 만들 수 있는 문자열을 map의 key로 사용하고 해당 문자열이 존재하면
value += 1, 없으면 1로 생성해주는 식으로 풀었습니다.
   
---
### 문제 2: 여왕벌 
**문제 난이도**
 골드3


**문제 유형**
구현, 시뮬레이션


 **접근 방식 및 풀이**
왼쪽 끝 열과, 맨 위의 행의 성장 총 합을 먼저 계산해주었습니다. 
그러고 1,1부터 M,M까지 돌면서 왼, 왼위, 위 3가지 값 중 제일 큰 값을 더해주는 식으로 구현했습니다.
이렇게 하면 최악의 경우에 시간초과라서 마지막 테스트는 통과하지 못했습니다.
이를 해결하기 위한 방법은 떠오르지 않아서 다른 분들의 풀이를 보고 공부해보겠습니다!
---
### 문제 3: 트리
 **문제 유형**






 **접근 방식 및 풀이**


---
### 문제 4: 거울 설치
 **문제 유형**



 **접근 방식 및 풀이**


---
### 문제 5: 경쟁적 전염
**문제 난이도**
 골드5

**문제 유형**
BFS

 **접근 방식 및 풀이**
맨 처음에 들어온 map에서 바이러스의 번호에 맞게 List에 추가해주었습니다.
이 때, 첫 풀이에서는 1~k가 하나씩만 들어오는 줄 알고 단순히 int배열로 해서 틀렸습니다.
그래서 List<Virus>[] 배열로 만들어서 각 번호에 맞는 virus를 추가해주었습니다.

그러고 제일 낮은 바이러스부터 queue에다가 넣어 주었고, 이후로 bfs를 실행하는 방식으로 구현했습니다.

