### PR TITLE
[김유성-9주차 알고리즘 스터디]

### DIFF
--- a/김유성-9주차/Main12837_가계부
+++ b/김유성-9주차/Main12837_가계부
@@ -1,0 +1,75 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main{
+	static int N, Q, K, set_val;
+	static long seg[];
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+	}
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		Q = Integer.parseInt(st.nextToken());
+		K = getSize();
+		
+		seg = new long [(int)Math.pow(2, K)];
+		set_val = (int)Math.pow(2, K - 1);
+		
+		for (int i = 0; i < Q; i++) {
+			st = new StringTokenizer(br.readLine());
+			int act = Integer.parseInt(st.nextToken());
+			if (act == 1) {
+				int p = Integer.parseInt(st.nextToken());
+				int x = Integer.parseInt(st.nextToken());
+				add(p, x);				
+			} else {
+				int p = Integer.parseInt(st.nextToken());
+				int q = Integer.parseInt(st.nextToken());
+				System.out.println(get(p, q));
+			}
+		}
+	}
+	
+	static int getSize() {
+		int k = 0;
+		
+		while (Math.pow(2, k) < N) {
+			k++;
+		}
+		return k + 1;
+	}
+	
+	static void add(int index, int x) {
+		index += set_val;
+		
+		while (index >= 1) {
+			seg[index] += x;
+			index /= 2;
+		}
+	}
+	
+	static long get(int start, int end) {
+		long ret = 0;
+		start += set_val;
+		end += set_val;
+		
+		while (start <= end) {
+			if (start % 2 == 1) {
+				ret += seg[start];
+			}
+			if (end % 2 == 0) {
+				ret += seg[end];
+			}
+			start = (start + 1) / 2;
+			end = (end - 1) / 2;
+		}
+		return ret;
+	}
+}

--- a/김유성-9주차/Main1477_휴게소_세우기
+++ b/김유성-9주차/Main1477_휴게소_세우기
@@ -1,0 +1,74 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	static int N, M, L;
+	static List<Integer> between = new ArrayList<>();
+
+	public static void main(String[] args) throws IOException {
+		init();
+		getMax();
+	}
+
+	static void getMax() {
+		int start = 1, end = between.get(between.size() - 1);
+		int mid = 0;
+		while (start <= end) {
+			mid = (start + end) / 2;
+
+			// 몇개까지 가능한지 체크. M보다 크거나 같으면 -> 이 때만 확인
+			int num = 0;
+			for (int len : between) {
+				num += (len - 1) / mid;
+			}
+			if (num <= M) {
+				end = mid - 1;
+			} else {
+				start = mid + 1;
+			}
+		}
+		System.out.println(start);
+	}
+
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		L = Integer.parseInt(st.nextToken());
+
+		between = new ArrayList<>();
+		int[] rest = new int[N + 2];
+
+		st = new StringTokenizer(br.readLine());
+		for (int n = 0; n < N; n++) {
+			int input = Integer.parseInt(st.nextToken());
+			rest[n + 1] = input;
+		}
+		rest[0] = 0;
+		rest[N + 1] = L;
+
+		Arrays.sort(rest);
+//		System.out.println(Arrays.toString(rest));
+		for (int i = 0; i < N + 1; i++) {
+			int a = rest[i];
+			int b = rest[i + 1];
+			between.add(b - a);
+		}
+		Collections.sort(between);
+//		System.out.println(between.toString());
+	}
+
+}

--- a/김유성-9주차/Main2186_문자판
+++ b/김유성-9주차/Main2186_문자판
@@ -1,0 +1,68 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static int N, M, K, ret = 0;
+	static char[][] map;
+	static List<int[]>[] alpha_index;
+	static int[][] move = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	public static void main(String[] args) throws IOException {
+		init();
+		String str = br.readLine();
+		List<int[]> list = alpha_index[str.charAt(0) - 'A'];
+		for (int[] arr: list) {
+			dfs(str, arr[0], arr[1], 1);
+		}
+		System.out.println(ret);
+	}
+	
+	static void dfs(String str, int n, int m, int len) {
+		if (str.length() == len) {
+			ret++;
+			return;
+		}
+		
+		for (int i = 0; i < 4; i++) {
+			for (int k = 1; k <= K; k++) {
+				int nn = n + move[i][0] * k;
+				int nm = m + move[i][1] * k;
+
+				if (nn >= 0 && nn < N && nm >= 0 && nm < M) {
+					if (map[nn][nm] == str.charAt(len))
+						dfs(str, nn, nm, len + 1);
+				}
+			}
+		}
+	}
+
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+		K = Integer.parseInt(st.nextToken());
+
+		map = new char[N][M];
+		alpha_index = new LinkedList[26];
+
+		for (int i = 0; i < 26; i++)
+			alpha_index[i] = new LinkedList<int[]>();
+
+		for (int n = 0; n < N; n++) {
+			String line = br.readLine();
+			for (int m = 0; m < M; m++) {
+				map[n][m] = line.charAt(m);
+				alpha_index[map[n][m] - 'A'].add(new int[] { n, m });
+			}
+		}
+	}
+}

--- a/김유성-9주차/Main4195_친구네트워크
+++ b/김유성-9주차/Main4195_친구네트워크
@@ -1,0 +1,77 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+public class Main {
+
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+	static int[] parents, friends_num;
+	public static void main(String[] args) throws IOException {
+		int T = Integer.parseInt(br.readLine());
+		while (T-- > 0) {
+			init();
+		}
+	}
+
+	static void init() throws IOException {
+		int F = Integer.parseInt(br.readLine());
+		Map<String, Integer> relation = new HashMap<>();
+		parents = new int [F * 2];
+		friends_num = new int [F * 2];
+				
+		if (F == 0)
+			System.out.println(0);
+		
+		Arrays.fill(friends_num, 1);
+		for (int i = 0; i < F * 2; i++) {
+			parents[i] = i;
+		}
+		
+		int index = 0;
+		for (int f = 0; f < F; f++) {
+			st = new StringTokenizer(br.readLine());
+			String a = st.nextToken();
+			String b = st.nextToken();
+
+			int num_a = relation.getOrDefault(a, index++);
+			int num_b = relation.getOrDefault(b, index++);
+			
+			relation.put(a, num_a);
+			relation.put(b, num_b);
+			
+			num_a = find(num_a);
+			num_b = find(num_b);
+			
+			if (num_a == num_b)
+				System.out.println(friends_num[num_a]);
+			else
+				System.out.println(friends_num[union(num_a, num_b)]);
+			
+		}
+	}
+	
+	static int find(int i) {
+		if (parents[i] == i)
+			return i;
+		return parents[i] = find(parents[i]);
+	}
+	
+	 static int union(int a, int b) {
+		 a = find(a);
+		 b = find(b);
+		 if (a < b) {
+			 friends_num[a] += friends_num[b];
+			 return parents[b] = a;
+		 }
+		 friends_num[b] += friends_num[a];
+		 return parents[a] = b;
+		 
+	 }
+}

--- a/김유성-9주차/Main_17485_진우의_달_여행
+++ b/김유성-9주차/Main_17485_진우의_달_여행
@@ -1,0 +1,80 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static StringTokenizer st;
+
+	static int N, M, map[][];
+	static long dp[][][];
+
+	public static void main(String[] args) throws IOException {
+		init();
+		dp();
+		getMin();
+	}
+
+	static void getMin() {
+		long min = Long.MAX_VALUE;
+
+		for (int m = 1; m <= M; m++) {
+			for (int i = 0; i < 3; i++) {
+				min = Math.min(min, dp[N -1][m][i]);
+			}
+		}
+		System.out.println(min);
+	}
+
+	static void dp() {
+		for (int n = 1; n < N; n++) {
+			for (int i = 0; i < 3; i++) {
+				dp[n][0][i] = Integer.MAX_VALUE;
+				dp[n][M + 1][i] = Integer.MAX_VALUE;
+			}
+				
+			for (int m = 1; m <= M; m++) {
+				
+				
+				long min1 = Math.min(dp[n - 1][m + 1][1], dp[n - 1][m + 1][2]);
+				dp[n][m][0] = map[n][m] + min1;
+
+				
+				long min2 = Math.min(dp[n - 1][m][0], dp[n - 1][m][2]);
+				dp[n][m][1] = map[n][m] + min2;
+
+				
+				long min3 = Math.min(dp[n - 1][m - 1][0], dp[n - 1][m - 1][1]);
+				dp[n][m][2] = map[n][m] + min3;
+			}
+		}
+		
+	}
+
+	static void init() throws IOException {
+		st = new StringTokenizer(br.readLine());
+		N = Integer.parseInt(st.nextToken());
+		M = Integer.parseInt(st.nextToken());
+
+		map = new int[N][M + 2];
+		dp = new long[N][M + 2][3];
+		for (int n = 0; n < N; n++) {
+			st = new StringTokenizer(br.readLine());
+			for (int m = 1; m < M + 1; m++)
+				map[n][m] = Integer.parseInt(st.nextToken());
+		}
+
+		for (int n = 0; n < N; n++) {
+			map[n][0] = Integer.MAX_VALUE;
+			map[n][M + 1] = Integer.MAX_VALUE;
+		}
+
+		for (int m = 0; m < M + 2; m++) {
+			for (int i = 0; i < 3; i++) {
+				dp[0][m][i] = map[0][m];
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 9주차 [김유성] 

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **친구 네트워크**
  - [x] **휴게소 세우기**  
  - [x] **진우의 달 여행**
  - [ ] **게리맨더링 2**  
  - [x] **가계부** 

 - 추가 문제
  - [ ] **문자판**

---

## 💡 풀이 방법
### 문제 1: 친구 네트워크

**문제 난이도**
골드 2


**문제 유형**
분리 집합

 **접근 방식 및 풀이**
틀린 풀이: Node클래스를 만들어서 node리스트와, 각 node의 index를 저장하는 배열을 만들었습니다.
node에는 친구 수와 root node를 저장해주었습니다.
단순히 root를 계속 탐색해서 찾아가기 때문에 시간초과가 발생하였습니다.


정답 풀이: 정석인 union, find 방식을 사용했습니다. 이 방식을 사용하기 위해서 주어진 인원들의 부모를 
가리키는 배열(parents)과 (맨 처음에는 자기자신을 부모로 가지고 있음), 각각의 친구 수를 (맨 처음에는 전부 1명)
저장하는 배열을 만들었습니다.
map에는 이름을 key로 해서 parents의 index를 저장하였고, 이를 이용해서 union, find로 값을 구해주었습니다.

---

### 문제 2: 휴게소 세우기 

**문제 난이도**
골드 4


**문제 유형**
이분 탐색

 **접근 방식 및 풀이**
휴게소의 좌표를 저장할 배열을 만들어서 저장 후, 맨 앞을 시작인 0으로, 맨 끝에 L을 저장해주었습니다.
그리고 정렬 후, 각 구간의 길이를 담는 리스트를 만들어서 저장해주고 정렬하였습니다. (리스트로 한 이유는 첫 접근 때
무조건 긴 거를 절반으로 나눠서 다시 구간을 담을 리스트에 넣어서 정렬하고 다시 제일 긴 값을 절반씩 나누는 식으로 접근했기
때문에 리스트로 했습니다.)

그리고, 이분탐색을 통해서 각 구간이 주어진 구간으로 몇개까지 나눠질 수 있는지 확인하면서 문제에서 주어진 새로
세울 수 있는 휴게소의 수보다 작거나 같으면 end를 작게 하여 탐색하고, 크면 start를 크게 하여 탐색하였습니다.

---

### 문제 3: 진우의 달 여행 
**문제 난이도**
골드 5


**문제 유형**
DP

 **접근 방식 및 풀이**
dp를 3차원 배열로 해서 각 행, 열에 추가로 올 수 있는 방향이 /, |, \  이렇게 3가지 이기 때문에 dp[][][3]으로 만들었습니다.
이 때, 열의 맨 처음과 끝은 padding처리해주어서 MAX_VALUE로 채워주었습니다. 이렇게 해서 해당 방향에서 오는 경우는
막아주었습니다.

dp를 채우는 방식
/ 는 [n - 1][m + 1]에서 가능. 그러면 이전에 \ or |에서 온 경우만 가능
| 는 [n - 1][m]에서 가능. 그러면 이전에 / or \에서 온 경우만 가능
\ 는 [n - 1][m - 1]에서 가능. 그러면 이전에 / or |에서 온 경우만 가능

이를 이용해서 dp를 채워주고, 이후에 맨 마지막 행만 확인해서 최소값을 구해주었습니다.

+추가로 다시 로직을 살펴보니 map에도 padding값을 주었는데 이 경우는 필요 없었던 것 같습니다.

---

### 문제 4: 게리맨더링 2
**문제 난이도**



**문제 유형**



 **접근 방식 및 풀이**

---
### 문제 5: 가계부 
**문제 난이도**
골드 1


**문제 유형**
세그먼트 트리


 **접근 방식 및 풀이**
단순 세그먼트 트리를 사용해서 푸는 문제였습니다.
add는 해당 index부터 위로 올라가면서 새로 들어온 값으로 node들을 갱신시켜주는 함수이고,
get은 주어진 구간의 합을 구하는 함수입니다.

---
### 추가문제 : 문자판
**문제 난이도**
골드 3


**문제 유형**
dfs

 **접근 방식 및 풀이**
처음에는 단순 bfs로 풀었는데 메모리 초과가 발생하였습니다.
두 번째로는 dfs를 이용해서 풀었는데 시간초과가 발생하였습니다.

처음 map을 저장할 때, 각 알파벳 별로 시작하는 좌표들을 list에 저장해 주어서 최적화가 가능하다고 생각했었는데
주어진 문자열의 길이가 길어서 메모이제이션 방식을 추가로 사용해야 하는 것 같습니다.
아직 dfs, bfs에서의 시간초과가 메모리 초과를 고려하는게 쉽지 않네요!

