### PR TITLE
[유병규-11주차 알고리즘 스터디]

### DIFF
--- a/유병규_11주차/[BOJ-13397] 구간 나누기 2.java
+++ b/유병규_11주차/[BOJ-13397] 구간 나누기 2.java
@@ -1,0 +1,62 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int[] numbers;
+	private static int n,m;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        
+        numbers = new int[n+1];
+        st = new StringTokenizer(br.readLine());
+        int max = 0;
+        int min = Integer.MAX_VALUE;
+        for(int i=1; i<=n; i++) {
+        	numbers[i] = Integer.parseInt(st.nextToken());
+        	max = Math.max(max, numbers[i]);
+        	min = Math.min(min, numbers[i]);
+        }
+        
+        int result = Integer.MAX_VALUE;
+        
+        int left = 0;
+        int right = max-min;
+        while(left <= right) {
+        	// mid = 구간 점수의 최댓값
+        	int mid = left + (right-left)/2;
+        	int count = counting(mid);
+        	if(count > m) {
+        		left = mid+1;
+        	}else {
+        		result = Math.min(result, mid);
+        		right = mid-1;
+        	}
+        }
+
+        System.out.println(result);
+    }
+
+	private static int counting(int mid) {
+		int count = 0;
+		int max = 0;
+		int min = Integer.MAX_VALUE;
+		
+		for(int i=1; i<=n; i++) {
+			max = Math.max(max, numbers[i]);
+			min = Math.min(min, numbers[i]);
+			if(mid >= max-min) continue;
+		
+			count++;
+			max = numbers[i];
+			min = numbers[i];
+		}
+		count++;
+		return count;
+	}
+}

--- a/유병규_11주차/[BOJ-1451] 직사각형으로 나누기.java
+++ b/유병규_11주차/[BOJ-1451] 직사각형으로 나누기.java
@@ -1,0 +1,115 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        
+        int[][] map = new int[n][m];
+        for(int i=0; i<n; i++) {
+        	String line = br.readLine();
+        	for(int j=0; j<m; j++) {
+        		map[i][j] = line.charAt(j)-'0';
+        	}
+        }
+        
+        int[][] sumMap = new int[n][m];
+        for(int i=0; i<n; i++) {
+        	for(int j=0; j<m; j++) {
+        		if(i==0 && j==0) sumMap[i][j] = map[i][j];
+        		else if(i==0) sumMap[i][j] = sumMap[i][j-1]+map[i][j];
+        		else if(j==0) sumMap[i][j] = sumMap[i-1][j]+map[i][j];
+        		else sumMap[i][j] = sumMap[i-1][j]+sumMap[i][j-1]-sumMap[i-1][j-1]+map[i][j];
+        	}
+        }
+        
+        int total = sumMap[n-1][m-1];
+        long max = 0;
+        
+        // 행이 1인 경우
+        if(n==1) {
+        	for(int i=0; i<m-2; i++) {
+        		int one = sumMap[0][i];
+        		for(int j=i+1; j<m-1; j++) {
+        			int two = sumMap[0][j] - one;
+        			int three = total-one-two;
+        			max = Math.max(max, (long) one*two*three);
+        		}
+        	}
+        	
+        	System.out.println(max);
+        	return;
+        }
+        
+        // 열이 1인 경우
+        if(m==1) {
+        	for(int i=0; i<n-2; i++) {
+        		int one = sumMap[i][0];
+        		for(int j=i+1; j<n-1; j++) {
+        			int two = sumMap[j][0] - one;
+        			int three = total-one-two;
+        			max = Math.max(max, (long) one*two*three);
+        		}
+        	}
+        	System.out.println(max);
+        	return;
+        }
+        
+        // 행과 열이 모두 2 이상인 경우
+        for(int i=0; i<n-1; i++) {
+        	for(int j=0; j<m-1; j++) {        		
+        		int one = sumMap[i][j];
+        		//case 1: 첫번째 구역의 아래를 두번째 구역으로
+        		int two = sumMap[n-1][j]-one;
+        		int three = total-one-two;
+        		max = Math.max(max, (long) one*two*three);
+        		//case 2: 첫번째 구역의 오른쪽을 두번째 구역으로
+        		two = sumMap[i][m-1]-one;
+        		three = total-one-two;
+        		max = Math.max(max, (long) one*two*three);
+        	}
+        }
+        
+        //첫번째 구역이 i행의 모든 열을 포함하는 경우
+        for(int i=0; i<n-1; i++) {
+        	int one = sumMap[i][m-1];
+        	//case 3: 남은 구역을 세로로 나눠먹는 경우
+        	for(int j=0; j<m-1; j++) {
+        		int two = sumMap[n-1][j] - sumMap[i][j];
+        		int three = total-one-two;
+        		max = Math.max(max, (long) one*two*three);
+        	}
+        	//case 4: 남은 구역을 가로로 나눠먹는 경우
+        	for(int j=i+1; j<n-1; j++) {
+    			int two = sumMap[j][m-1] - one;
+    			int three = total-one-two;
+    			max = Math.max(max, (long) one*two*three);
+    		}
+        }
+        
+        //첫번째 구역이 i열의 모든 행을 포함하는 경우
+        for(int j=0; j<m-1; j++) {
+        	int one = sumMap[n-1][j];
+        	//case 5: 남은 구역을 가로로 나눠먹는 경우
+        	for(int i=0; i<n-1; i++) {
+        		int two = sumMap[i][m-1] - sumMap[i][j];
+        		int three = total-one-two;
+        		max = Math.max(max, (long) one*two*three);
+        	}
+        	//case 6: 남은 구역을 세로로 나눠먹는 경우
+        	for(int i=j+1; i<m-1; i++) {
+    			int two = sumMap[n-1][i] - one;
+    			int three = total-one-two;
+    			max = Math.max(max, (long) one*two*three);
+    		}
+        }
+        
+        System.out.println(max);
+    }
+}

--- a/유병규_11주차/[BOJ-20055] 컨베이어 벨트 위의 로봇.java
+++ b/유병규_11주차/[BOJ-20055] 컨베이어 벨트 위의 로봇.java
@@ -1,0 +1,74 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        st = new StringTokenizer(br.readLine());
+
+        LinkedList<Block> up = new LinkedList<>();
+        for(int i=0; i<n; i++) {
+        	up.addFirst(new Block(Integer.parseInt(st.nextToken())));
+        }
+        LinkedList<Block> down = new LinkedList<>();
+        for(int i=0; i<n; i++) {
+        	down.addFirst(new Block(Integer.parseInt(st.nextToken())));
+        }
+        
+        int step = 0;
+        int count = 0;
+        while(true) {
+        	step++;
+        	//1. 회전
+        	down.add(up.poll());
+        	up.add(down.poll());
+        	up.peek().robot = false;
+        	//2. 로봇 이동
+        	for(int i=1; i<up.size(); i++) {
+        		Block current = up.get(i);
+        		if(!current.robot) continue;
+        		Block next = up.get(i-1);
+        		if(next.robot || next.durability == 0) continue;
+        		current.robot = false;
+        		next.robot = true;
+        		next.durability--;
+        		if(next.durability == 0) count++;
+        		if(i-1 == 0) {
+        			next.robot = false;
+        		}
+        	}
+        	//3. 로봇 올리기
+        	Block b = up.getLast();
+        	if(b.durability != 0) {
+        		b.robot = true;
+        		b.durability--;
+        		if(b.durability == 0) count++;
+        	}
+        	//4. 확인
+        	if(count >= k) break;
+        }
+        
+        System.out.println(step);
+    }
+    
+    private static class Block{
+    	int durability;
+    	boolean robot;
+    	
+    	public Block(int durability) {
+    		this.durability = durability;
+    		this.robot = false;
+    	}
+    	
+    	@Override
+    	public String toString() {
+    		return "["+durability+","+robot+"]";
+    	}
+    }
+}

--- a/유병규_11주차/[BOJ-2479] 경로 찾기.java
+++ b/유병규_11주차/[BOJ-2479] 경로 찾기.java
@@ -1,0 +1,75 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int[][] map;
+	private static int k;
+	private static int[] numbers;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        
+        numbers = new int[n];
+        for(int i=0; i<n; i++) {
+        	numbers[i] = Integer.parseInt(br.readLine(), 2);
+        }
+        
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken())-1;
+        int end = Integer.parseInt(st.nextToken())-1;
+        
+        map = new int[n][n];
+        
+        Queue<Node> q = new LinkedList<>();
+        boolean[] visited = new boolean[n];
+        q.offer(new Node(start, (start+1)+""));
+        visited[start] = true;
+        while(!q.isEmpty()) {
+        	Node node = q.poll();
+        	int current = node.num;
+        	
+        	if(current == end) {
+        		System.out.println(node.path);
+        		return;
+        	}
+        	
+        	for(int i=0; i<n; i++) {
+        		if(visited[i]) continue;
+        		if(map[current][i] > 1) continue;
+        		if(dist(current, i) != 1) continue;
+        		q.offer(new Node(i, node.path+" "+(i+1)));
+        		visited[i] = true;
+        	}
+        }
+        
+        System.out.println(-1);
+    }
+    
+    private static int dist(int idx1, int idx2) {
+    	int a = numbers[idx1];
+    	int b = numbers[idx2];
+			int dist = 0;
+			int number = a ^ b;
+		
+			for(int i=0; i<k; i++) {
+				if((number & (1 << i)) != 0) dist++;
+				
+			}
+			map[idx1][idx2] = dist;
+			return dist;
+		}
+	
+		private static class Node{
+    	int num;
+    	String path;
+    	
+    	public Node(int num, String path) {
+    		this.num = num;
+    		this.path = path;
+    	}
+    }
+}

--- a/유병규_11주차/[BOJ-7662] 이중 우선순위 큐.java
+++ b/유병규_11주차/[BOJ-7662] 이중 우선순위 큐.java
@@ -1,0 +1,42 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringBuilder sb = new StringBuilder();
+        int T = Integer.parseInt(br.readLine());
+        for(int test=0; test<T; test++) {
+        	int k = Integer.parseInt(br.readLine());
+        	
+        	TreeMap<Integer, Integer> treemap = new TreeMap<>();
+        	
+        	for(int i=0; i<k; i++) {
+        		StringTokenizer st = new StringTokenizer(br.readLine());
+        		String oper = st.nextToken();
+        		int value = Integer.parseInt(st.nextToken());
+        		
+        		if(oper.equals("I")) {
+        			treemap.put(value, treemap.getOrDefault(value, 0)+1);
+        			continue;
+        		}
+        		if(treemap.isEmpty()) continue;
+        		int key = (value == 1) ? treemap.lastKey() : treemap.firstKey();
+        		int count = treemap.get(key);
+        		
+        		if(count == 1) treemap.remove(key);
+        		else treemap.put(key, count-1);
+        	}
+        	
+        	if(treemap.isEmpty()) {
+        		sb.append("EMPTY").append("\n");
+        		continue;
+        	}
+        	sb.append(treemap.lastKey()).append(" ").append(treemap.firstKey()).append("\n");
+        }
+        
+        System.out.println(sb.toString().trim());
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 11주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **직사각형으로 나누기**
- [x]  **경로 찾기**
- [x]  **컨베이어 벨트 위의 로봇**
- [x]  **이중 우선순위 큐**
- [x]  **구간 나누기 2**

---

- [ ]  **도로검**
- [ ]  **팰린드롬 분할**
- [ ]  **복제 로봇**

---

## 💡 풀이 방법

### 문제 1: 직사각형으로 나누기

**문제 난이도**

- 골드 4

**문제 유형**

- 구현, 브루트포스, 누적 합, 많은 조건 분기

**접근 방식 및 풀이**

- 모든 경우의 수를 계산하여 답을 구하는 문제로 해석했습니다.
- 각 직사각형의 합을 여러 번 계산하는 데, 중복 계산을 피하기 위해 누적 합을 사용해 합 배열을 먼저 생성하였습니다.
- 아래와 같은 경우로 나누어 문제를 해결하였습니다.
- 세 직사각형의 곱을 long 타입으로 설정해주는 것을 유의해야합니다.

---

### 문제 2: 경로 찾기

**문제 난이도**

- 골드 4

**문제 유형**

- BFS

**접근 방식 및 풀이**

- 두 코드 사이의 거리를 xor 연산으로 계산한 후 거리가 1인 코드를 각 정점으로 BFS를 수행하여 문제를 해결하였습니다.

---

### 문제 3: 컨베이어 벨트 위의 로봇

**문제 난이도**

- 골드 5

**문제 유형**

- 구현, 시뮬레이션

**접근 방식 및 풀이**

- 문제 요구 사항을 그대로 구현하였습니다. 처음에는 Deque를 사용하려 했으나 로봇을 움직이는 과정에서 중간 연산을 수행할 수 없어 LinkedList로 구현하였습니다.

---

### 문제 4: 이중 우선순위 큐

**문제 난이도**

- 골드 4

**문제 유형**

- 자료구조, 트리, 우선순위 큐

**접근 방식 및 풀이**

- 처음에는  최댓값을 저장하는 우선순위 큐와 최솟값을 저장하는 우선순위 큐, 총 2개의 우선순위 큐로 구현하였는데 시간 초과가 났습니다. 최댓값이나 최솟값을 제거할 때 다른 쪽의 우선순위 큐에서 해당 값을 remove하는데, 이 작업이 $N \log N$의 시간이 걸리기 때문에 시간 초과가 난 것 같습니다. 그래서 다른 자료구조로 TreeMap을 사용해서 문제를 해결하였습니다. TreeMap의 경우 삽입/삭제/검색의 연산이 모두 $\log N$의 시간이 걸리기 때문에 시간 초과를 해결할 수 있었습니다.

---

### 문제 5: 구간 나누기 2

**문제 난이도**

- 골드 4

**문제 유형**

- 이분 탐색, 매개 변수 탐색

**접근 방식 및 풀이**

- 처음에는 DP 문제인 줄 알고 DP로 구현했습니다. 하지만 시간 초과가 났고, DP 외 접근 방법이 이분 탐색 밖에 떠오르지 않아 이분 탐색으로 접근하였습니다.
- 이분 탐색 값을 구간 점수의 최댓값으로 하고 초기 `left=0`, `right=현재 배열의 구간 점수`로 설정하여 `mid`값을 기준으로 해당 `mid`값이 구간 점수의 최댓값으로 만들기 위한 구간의 개수를 세어 문제를 해결하였습니다.

---