### PR TITLE
[권혁준-16주차 알고리즘 스터디]

### DIFF
--- a/권혁준_16주차/[BOJ-13141] Ignition.md
+++ b/권혁준_16주차/[BOJ-13141] Ignition.md
@@ -1,0 +1,38 @@
+# CPP
+```cpp
+#include <iostream>
+#include <tuple>
+#include <algorithm>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, M, D[201][201]{}, INF = 1e9 + 7;
+	cin >> N >> M;
+	tuple<int, int, int> E[20000]{};
+	for (int i = 1; i <= N; i++) for (int j = 1; j <= N; j++) if(i != j) D[i][j] = INF;
+	for (int i = 0, a, b, c; i < M; i++) {
+		cin >> a >> b >> c;
+		D[b][a] = D[a][b] = min(D[a][b], c);
+		E[i] = { a,b,c };
+	}
+
+	for (int i = 1; i <= N; i++) for (int j = 1; j <= N; j++) for (int k = 1; k <= N; k++) {
+		int res = D[j][i] + D[i][k];
+		D[j][k] = min(D[j][k], D[j][i] + D[i][k]);
+	}
+
+	int ans = INF;
+	for (int i = 1; i <= N; i++) {
+		int res = 0;
+		for (int j = 0; j < M; j++) {
+			auto[s, e, l] = E[j];
+			res = max(res, D[i][s] + l + D[i][e]);
+		}
+		ans = min(ans, res);
+	}
+	cout << ans / 2 << "." << ((ans & 1) ? "5" : "0");
+
+}
+```

--- a/권혁준_16주차/[BOJ-13905] 세부.md
+++ b/권혁준_16주차/[BOJ-13905] 세부.md
@@ -1,0 +1,103 @@
+# JAVA
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M, S, E;
+	static int[] r;
+	static int[][] edges;
+	
+	static int f(int x) {return x==r[x] ? x : (r[x]=f(r[x]));}
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		S = nextInt();
+		E = nextInt();
+		r = new int[N+1];
+		for(int i=1;i<=N;i++) r[i] = i;
+		edges = new int[M][];
+		for(int i=0;i<M;i++) edges[i] = new int[] {nextInt(), nextInt(), nextInt()};
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		Arrays.sort(edges, (a,b) -> b[2]-a[2]);
+		for(int[] e:edges) {
+			int a = e[0], b = e[1], c = e[2];
+			int x = f(a), y = f(b);
+			if(x == y) continue;
+			r[x] = y;
+			if(f(S) == f(E)) {
+				bw.write(c + "\n");
+				return;
+			}
+		}
+		bw.write("0");
+		
+	}
+	
+}
+```
+
+# CPP
+```cpp
+#include <iostream>
+#include <numeric>
+#include <queue>
+#include <functional>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, M, S, E, r[100001]{};
+	cin >> N >> M >> S >> E;
+
+	iota(r, r + N + 1, 0);
+	function<int(int)> f = [&](int x) -> int {return x == r[x] ? x : r[x] = f(r[x]); };
+
+	priority_queue<tuple<int, int, int>> Q;
+	for (int a, b, c; M--; Q.emplace(c, a, b)) cin >> a >> b >> c;
+
+	while (!Q.empty()) {
+		auto[c, a, b] = Q.top(); Q.pop();
+		int x = f(a), y = f(b);
+		if (x == y) continue;
+		r[x] = y;
+		if (f(S) == f(E)) return cout << c, 0;
+	}
+	cout << 0;
+
+}
+```

--- a/권혁준_16주차/[BOJ-15653] 구슬 탈출 4.md
+++ b/권혁준_16주차/[BOJ-15653] 구슬 탈출 4.md
@@ -1,0 +1,60 @@
+# CPP
+```cpp
+#include <iostream>
+#include <tuple>
+#include <queue>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int dx[4] = { 1,0,-1,0 };
+	int dy[4] = { 0,1,0,-1 };
+
+	int N, M;
+	cin >> N >> M;
+	char A[10][10]{};
+	int px, py, qx, qy;
+
+
+	for (int i = 0; i < N; i++) for (int j = 0; j < M; j++) {
+		cin >> A[i][j];
+		if (A[i][j] == 'R') px = i, py = j, A[i][j] = '.';
+		if (A[i][j] == 'B') qx = i, qy = j, A[i][j] = '.';
+	}
+
+	int vis[10][10][10][10]{};
+	vis[px][py][qx][qy]++;
+	queue<tuple<int, int, int, int, int>> Q;
+	Q.emplace(px, py, qx, qy, 0);
+	while (!Q.empty()) {
+		auto[ax, ay, bx, by, t] = Q.front();
+		Q.pop();
+		if (A[ax][ay] == 'O') return cout << t, 0;
+
+		for (int i = 0; i < 4; i++) {
+			int fx = ax, fy = ay, gx, gy;
+			while (!(fx == bx && fy == by) && A[fx][fy] == '.') fx += dx[i], fy += dy[i];
+			if (fx == bx && fy == by) {
+				gx = bx, gy = by;
+				while (A[gx][gy] == '.') gx += dx[i], gy += dy[i];
+				if (A[gx][gy] == 'O') continue;
+				gx -= dx[i], gy -= dy[i];
+				fx = gx - dx[i], fy = gy - dy[i];
+			}
+			else {
+				if (A[fx][fy] == '#') fx -= dx[i], fy -= dy[i];
+				gx = bx, gy = by;
+				while (!(gx == fx && gy == fy) && A[gx][gy] == '.') gx += dx[i], gy += dy[i];
+				if (A[gx][gy] == 'O') continue;
+				gx -= dx[i], gy -= dy[i];
+			}
+			if (vis[fx][fy][gx][gy]) continue;
+			vis[fx][fy][gx][gy]++;
+			Q.emplace(fx, fy, gx, gy, t + 1);
+		}
+	}
+	cout << -1;
+
+}
+```

--- a/권혁준_16주차/[BOJ-1727] 커플 만들기.md
+++ b/권혁준_16주차/[BOJ-1727] 커플 만들기.md
@@ -1,0 +1,43 @@
+# CPP
+```cpp
+#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int N, M, A[1001]{}, B[1001]{};
+int dp[1001]{}, mn[1001]{};
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	cin >> N >> M;
+	for (int i = 1; i <= N; i++) cin >> A[i];
+	for (int i = 1; i <= M; i++) cin >> B[i];
+	sort(A + 1, A + N + 1);
+	sort(B + 1, B + M + 1);
+
+	if (N > M) {
+		swap(N, M);
+		swap(A, B);
+	}
+
+	int ans = 2e9;
+	for (int j = 1; j <= M; j++) {
+		dp[j] = abs(A[1] - B[j]);
+		mn[j] = j == 1 ? dp[j] : min(mn[j - 1], dp[j]);
+		if (N == 1) ans = min(ans, dp[j]);
+	}
+
+	for (int i = 2; i <= N; i++) {
+		int ndp[1001]{}, nmn[1001]{};
+		for (int j = i; j <= M; j++) {
+			ndp[j] = mn[j - 1] + abs(A[i] - B[j]);
+			nmn[j] = j == i ? ndp[j] : min(nmn[j - 1], ndp[j]);
+			if (i == N) ans = min(ans, ndp[j]);
+		}
+		for (int j = 1; j <= M; j++) dp[j] = ndp[j], mn[j] = nmn[j];
+	}
+	cout << ans;
+
+}
+```

--- a/권혁준_16주차/[BOJ-17951] 흩날리는 시험지 속에서 내 평점이 느껴진거야.md
+++ b/권혁준_16주차/[BOJ-17951] 흩날리는 시험지 속에서 내 평점이 느껴진거야.md
@@ -1,0 +1,99 @@
+# JAVA
+
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, K;
+	static int[] A;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		K = nextInt();
+		A = new int[N];
+		for(int i=0;i<N;i++) A[i] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		int s = 0, e = 2000000, m = (s+e+1)>>1;
+		while(s<e) {
+			int cnt = 1, sum = 0;
+			for(int i:A) {
+				sum += i;
+				if(sum >= m) {
+					sum = 0;
+					cnt++;
+				}
+			}
+			if(cnt > K) s = m;
+			else e = m-1;
+			m = (s+e+1)>>1;
+		}
+		bw.write(m + "\n");
+		
+	}
+	
+}
+```
+
+# CPP
+
+```cpp
+#include <iostream>
+#include <vector>
+using namespace std;
+
+int main() {
+	cin.tie(0)->sync_with_stdio(0);
+
+	int N, K;
+	cin >> N >> K;
+	vector<int> A(N);
+	for (int &i : A) cin >> i;
+
+	int s = 0, e = 2000000, m = (s + e + 1) >> 1;
+	while (s < e) {
+		int cnt = 1, sum = 0;
+		for (int i : A) {
+			sum += i;
+			if (sum >= m) cnt++, sum = 0;
+		}
+		if (cnt > K) s = m;
+		else e = m - 1;
+		m = (s + e + 1) >> 1;
+	}
+	cout << m;
+
+}
+```


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 16주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [x] **흩날리는 시험지 속에서 내 평점이 느껴진거야**
  - [x] **구슬 탈출 4**  
  - [x] **세부**
  - [x] **커플 만들기**  
  - [x] **Ignition**  

---

## 💡 풀이 방법
### 문제 1: 흩날리는 시험지 속에서 내 평점이 느껴진거야

**문제 난이도**

Gold 3

**문제 유형**

- 매개 변수 탐색
- 이분 탐색

**접근 방식 및 풀이**

`최대 점수`를 x로 만들 수 있을 때, x 이하로도 항상 만들 수 있음을 보인다면 **이분 탐색 + 매개 변수 탐색**을 수행할 수 있습니다.
구간을 자를 때는 그리디하게, 합이 x를 넘겼다면 잘라주는 방식을 적용합니다.
그러면, (x로 만들었을 때의 구간 개수) <= (x 이하로 만들었을 때의 구간 개수) 가 성립합니다.

이분 탐색 범위의 상한은 맞은 문제의 합으로 생각해서 2000000으로 잡았습니다.

---


### 문제 2: 구슬 탈출 4

**문제 난이도**

Gold 1

**문제 유형**

- BFS
- 시뮬레이션

**접근 방식 및 풀이**

빨간 구슬과 파란 구슬의 위치를 상태로 가지는 BFS를 돌려주었습니다.

기울이기 작업이 조금 까다로웠는데, 저는 dx dy 배열과 while문 + 적당한 조건 분기로 구현했습니다.

---


### 문제 3: 세부

**문제 난이도**

Gold 3

**문제 유형**

- MST

**접근 방식 및 풀이**

일반적인 그래프에서 경로의 비용은 가중치의 합이지만, 이 문제에서는 가중치의 최솟값입니다.
따라서, 크루스칼을 돌리는데 간선 가중치가 큰 것부터 고려하여 해결했습니다.

---


### 문제 4: 커플 만들기

**문제 난이도**

Gold 2

**문제 유형**

- 정렬
- DP

**접근 방식 및 풀이**

**성격 차이의 합이 최소**가 되어야 함 -> 정렬 후, 포인터 이동시키는 느낌으로 DP를 돌려야겠다고 생각했습니다.

dp[i][j] = i번 남자와 j번 여자를 이어줬을 때의 최소 합.
mn[i][j] = i번 남자와 j번 여자까지만 고려했을 때의 최소 합.
이렇게 dp를 정의했고, 이로부터 dp[i][j] = mn[i-1][j-1] + abs(A[i] - B[j]) 라는 식을 얻었습니다.

이 dp식을 돌려, i >= min(N,M), j >= min(N,M)인 i,j에 대해 dp[i][j]의 최솟값을 구했습니다.

---


### 문제 5: Ignition

**문제 난이도**

Platinum 5

**문제 유형**

- 플로이드-워셜

**접근 방식 및 풀이**

`그래프를 모두 태운다 == 모든 간선을 태운다`라고 생각했습니다.
따라서 각 간선이 타게 되는 최소 시간을 구하는 방법을 떠올리려 했습니다.

불을 붙이는 정점을 i라고 했을 때, j번 정점이 타게 되는 최소 시간은 i에서 j로 가는 최단 시간입니다.

간선 (s,e,l)에 대해, 이 간선이 타는 방법은 둘 중 하나입니다.

1. 간선이 한 쪽 방향으로만 탐.
2. 간선의 양쪽에서 불이 붙어 타게 됨.

둘 모두 일반화할 수 있는 시간은 **(i -> s 최단 시간) + l + (i -> e 최단 시간)**이 됩니다.

모든 정점에 불을 붙여보며 최소 시간을 구해줬습니다.
