### PR TITLE
[유병규-16주차 알고리즘 스터디]

### DIFF
--- a/유병규_16주차/[BOJ-13905] 세부.java
+++ b/유병규_16주차/[BOJ-13905] 세부.java
@@ -1,0 +1,65 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        
+        st = new StringTokenizer(br.readLine());
+        
+        int s = Integer.parseInt(st.nextToken());
+        int e = Integer.parseInt(st.nextToken());
+        
+        List<Edge>[] graph = new ArrayList[n+1];
+        for(int i=1; i<=n; i++) {
+        	graph[i] = new ArrayList<>();
+        }
+        
+        for(int i=0; i<m; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	int a = Integer.parseInt(st.nextToken());
+        	int b = Integer.parseInt(st.nextToken());
+        	int c = Integer.parseInt(st.nextToken());
+        	graph[a].add(new Edge(b, c));
+        	graph[b].add(new Edge(a, c));
+        }
+        
+        boolean[] visited = new boolean[n+1];
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> -Integer.compare(o1[1], o2[1]));
+        pq.offer(new int[] {s, Integer.MAX_VALUE});
+        
+        while(!pq.isEmpty()) {
+        	int[] info = pq.poll();
+        	int current = info[0];
+        	
+        	if(current == e) {
+        		System.out.println(info[1]);
+        		return;
+        	}
+        	
+        	if(visited[current]) continue;
+        	visited[current] = true;
+        	for(Edge edge : graph[current]) {
+        		if(visited[edge.to]) continue;
+        		pq.offer(new int[] {edge.to, Math.min(info[1], edge.weight)});
+        	}
+        }
+        System.out.println(0);
+    }
+    
+    private static class Edge{
+    	int to;
+    	int weight;
+    	
+    	public Edge(int to, int weight) {
+    		this.to = to;
+    		this.weight = weight;
+    	}
+    }
+}

--- a/유병규_16주차/[BOJ-15653] 구슬 탈출 4.java
+++ b/유병규_16주차/[BOJ-15653] 구슬 탈출 4.java
@@ -1,0 +1,137 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int n,m;
+	private static int[] red,blue;
+	private static char[][] map;
+	private static int[][] d = {{-1,0},{1,0},{0,-1},{0,1}};
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        
+        map = new char[n][m];
+        for(int i=0; i<n; i++) {
+        	String line = br.readLine();
+        	for(int j=0; j<m; j++) {
+        		map[i][j] = line.charAt(j);
+        		if(map[i][j] == 'R') {
+        			red = new int[] {i,j};
+        			map[i][j] = '.';
+        		}
+        		if(map[i][j] == 'B') {
+        			blue = new int[] {i,j};
+        			map[i][j] = '.';
+        		}
+        	}
+        }
+        
+        int count = bfs();
+        System.out.println(count);
+    }
+    
+    private static int bfs() {
+    	Queue<int[]> q = new LinkedList<>();
+    	boolean[][][][] visited = new boolean[n][m][n][m];
+    	
+    	q.offer(new int[] {red[0], red[1], blue[0], blue[1], 0, 0, 4});
+    	visited[red[0]][red[1]][blue[0]][blue[1]] = true;
+    	
+    	while(!q.isEmpty()) {
+    		int[] info = q.poll();
+    		int rx = info[0];
+    		int ry = info[1];
+    		int bx = info[2];
+    		int by = info[3];
+    		int count = info[4];
+    		int dStart = info[5];
+    		int dCount = info[6];
+    		
+    		int dx = (bx-rx == 0) ? 0 : (bx-rx)/Math.abs(bx-rx);
+    		int dy = (by-ry == 0) ? 0 : (by-ry)/Math.abs(by-ry);
+    		To: for(int i=0; i<dCount; i++) {
+    			int idx = dStart+i;
+    			
+    			int nbx = bx + d[idx][0];
+    			int nby = by + d[idx][1];
+    			int nrx = rx + d[idx][0];
+    			int nry = ry + d[idx][1];
+    			
+    			if(OOB(nbx, nby) || OOB(nrx, nry)) continue;
+    			
+    			//블루 먼저
+    			if(dx == d[idx][0] && dy == d[idx][1]) {
+    				while(true) {
+    					if(map[nbx][nby] == 'O') continue To;
+    					if(map[nbx][nby] == '#') break;
+    					nbx += d[idx][0];
+    					nby += d[idx][1];
+    				}
+    				
+    				nbx -= d[idx][0];
+    				nby -= d[idx][1];
+    				
+    				while(true) {
+    					if(map[nrx][nry] == 'O') break;
+    					if(map[nrx][nry] == '#' || (nbx == nrx && nby == nry)) break;
+    					nrx += d[idx][0];
+    					nry += d[idx][1];
+    				}
+    				
+    				if(map[nrx][nry] == 'O') return count+1;
+    				
+    				nrx -= d[idx][0];
+    				nry -= d[idx][1];
+    				
+    				if(visited[nrx][nry][nbx][nby]) continue To;
+    				int ndStart = idx < 2 ? 2 : 0;
+    				q.offer(new int[] {nrx, nry, nbx, nby, count+1, ndStart, 2});
+    				visited[nrx][nry][nbx][nby] = true;
+    			}
+    			//레드 먼저
+    			else {
+    				while(true) {
+    					if(map[nrx][nry] == 'O') break;
+    					if(map[nrx][nry] == '#') break;
+    					nrx += d[idx][0];
+    					nry += d[idx][1];
+    				}
+    				
+    				if(map[nrx][nry] != 'O') {
+    					nrx -= d[idx][0];
+    					nry -= d[idx][1];    					
+    				}
+    				
+    				
+    				while(true) {
+    					if(map[nbx][nby] == 'O') continue To;
+    					if(map[nbx][nby] == '#' || (nbx == nrx && nby == nry)) break;
+    					nbx += d[idx][0];
+    					nby += d[idx][1];
+    				}
+    				
+    				nbx -= d[idx][0];
+    				nby -= d[idx][1];
+    				
+    				if(map[nrx][nry] == 'O') return count+1;
+    				
+    				if(visited[nrx][nry][nbx][nby]) continue To;
+    				int ndStart = idx < 2 ? 2 : 0;
+    				q.offer(new int[] {nrx, nry, nbx, nby, count+1, ndStart, 2});
+    				visited[nrx][nry][nbx][nby] = true;
+    			}
+    		}
+    	}
+    	
+    	return -1;
+    }
+
+	private static boolean OOB(int x, int y) {
+		if(x<0 || x>=n || y<0 || y>=m) return true;
+		return false;
+	}
+}

--- a/유병규_16주차/[BOJ-1727] 커플 만들기.java
+++ b/유병규_16주차/[BOJ-1727] 커플 만들기.java
@@ -1,0 +1,71 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        
+        int[] men = new int[n + 1];
+        int[] women = new int[m + 1];
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i=1; i<=n; i++) {
+            men[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        st = new StringTokenizer(br.readLine());
+        for (int i=1; i<=m; i++) {
+            women[i] = Integer.parseInt(st.nextToken());
+        }
+        
+        // 정렬
+        Arrays.sort(men);
+        Arrays.sort(women);
+        
+        // 작은 그룹과 큰 그룹 결정
+        int[] small, large;
+        int smallSize, largeSize;
+        
+        if (n <= m) {
+            small = men;
+            large = women;
+            smallSize = n;
+            largeSize = m;
+        } else {
+            small = women;
+            large = men;
+            smallSize = m;
+            largeSize = n;
+        }
+        
+        // DP 배열 초기화
+        long[][] dp = new long[smallSize+1][largeSize+1];
+        
+        // 초기값 설정
+        for (int i=0; i<=smallSize; i++) {
+            for (int j=0; j<i; j++) {
+                dp[i][j] = Long.MAX_VALUE;
+            }
+        }
+        
+        // DP 계산
+        for (int i=1; i<=smallSize; i++) {
+            for (int j=i; j<=largeSize; j++) {
+                if (j == i) {
+                    dp[i][j] = dp[i-1][j-1] + Math.abs(small[i] - large[j]);
+                } else {
+                    dp[i][j] = Math.min(
+                        dp[i][j-1],  // j번째 사람을 선택하지 않는 경우
+                        dp[i-1][j-1] + Math.abs(small[i] - large[j])  // j번째 사람을 선택하는 경우
+                    );
+                }
+            }
+        }
+        
+        System.out.println(dp[smallSize][largeSize]);
+    }
+}

--- a/유병규_16주차/[BOJ-17951] 흩날리는 시험지 속에서 내 평점이 느껴진거야.java
+++ b/유병규_16주차/[BOJ-17951] 흩날리는 시험지 속에서 내 평점이 느껴진거야.java
@@ -1,0 +1,60 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int n, k;
+	private static int[] num;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        
+        st = new StringTokenizer(br.readLine());
+        num = new int[n];
+        int sum = 0;
+        for(int i=0; i<n; i++) {
+        	num[i] = Integer.parseInt(st.nextToken());
+        	sum += num[i];
+        }
+
+        if(k == 1) {
+        	System.out.println(sum);
+        	return;
+        }
+        
+        int left = 0;
+        int right = sum;
+        int mid = 0;
+        while(left <= right) {
+        	mid = left + (right-left)/2;
+        	
+        	int count = counting(mid);
+        	
+        	if(count < k) {
+        		right = mid-1;
+        		continue;
+        	}
+
+        	left = mid+1;
+        }
+        
+        System.out.println(right);
+    }
+
+	private static int counting(int min) {
+		int count = 0;
+		
+		int sum = 0;
+		for(int i=0; i<n; i++) {
+			sum += num[i];
+			if(sum < min) continue;
+			count++;
+			sum = 0;
+		}
+
+		return count;
+	}
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 16주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **흩날리는 시험지 속에서 내 평점이 느껴진거야**
- [x]  **구슬 탈출 4**
- [x]  **세부**
- [x]  **커플 만들기**
- [ ]  **Ignition**

---

## 💡 풀이 방법

### 문제 1: 흩날리는 시험지 속에서 내 평점이 느껴진거야

**문제 난이도**

- 골드 3

**문제 유형**

- 이분 탐색, 매개 변수 탐색

**접근 방식 및 풀이**

- 주어진 수열을 `k`개의 그룹으로 나누었을 때 각 그룹의 총합의 최솟값의 최댓값을 구하는 문제입니다.
- 최솟값의 최댓값을 구하는 문제이기에 이분 탐색으로 접근하였습니다.
- 각 그룹의 총합의 최솟값을 `mid`로 설정하였습니다. 즉, 각 그룹의 총합은 최소한 `mid`값을 넘어야 함을 의미합니다.
- `counting` 함수는 `mid`를 전달 받아 수열에서 조건을 만족하는 그룹을 만들 수 있는 개수를 반환합니다.
- `count` 값에 따라 다음과 같이 조정합니다.
	- 그룹의 개수가 `k`보다 작을 경우: `mid` 값이 너무 큰 것이므로 `mid` 값을 줄인다
	- 그룹의 개수가 `k`보다 클 경우: `mid` 값이 너무 작은 것이므로 `mid` 값을 키운다.
	- 그룹의 개수가 `k`와 같을 경우: 최댓값을 찾는 것이 목표이므로 `mid` 값을 키운다.
- 이분탐색이 종료되었을 때 `right`와 `left`는 다음과 같은 의미를 가집니다.
	- `right`: 조건을 만족하는 값들 중 최댓값
	- `left`: 조건을 만족하지 않는 값들 중 최솟값
- 때문에 `right`를 반환하여 문제를 해결하였습니다.

---

### 문제 2: 구슬 탈출 4

**문제 난이도**

- 골드 1

**문제 유형**

- 구현, BFS, 시뮬레이션

**접근 방식 및 풀이**

- 빨간 구슬 위치와 파란 구슬 위치의 방문 처리를 4차원 배열로 저장하여 해결하였습니다.
- '기울이기'를 할 때 파란 구슬과 빨간 구슬 중 해당 방향으로 앞에 있는 구슬을 먼저 움직이도록 구현하였습니다.

---

### 문제 3: 세부

**문제 난이도**

- 골드 3

**문제 유형**

- 자료 구조, MST

**접근 방식 및 풀이**

- 프림 알고리즘을 사용하였고 이때 금빼빼로를 최대한 많이 가져가야 하기에 간선의 가중치가 작은 것이 아닌 큰 것을 기준으로 추가하였습니다.
- 문제에서 가져가지 못하는 경우는 주어지지 않는다라는 조건이 없으므로 만약 갈 수 없을 경우 '0'을 출력하도록 하여 문제를 해결하였습니다.

---

### 문제 4: 커플 만들기

**문제 난이도**

- 골드 2

**문제 유형**

- DP, 그리디, 정렬

**접근 방식 및 풀이**

- 우선 최대한 많은 커플을 만들기 때문에, 인원 수가 더 적은 그룹은 모두 커플을 이뤄야합니다.
- 인원 수가 더 적은 그룹의 인원 수를 a, 반대편을 b라고 할 때(`a<=b`) b개 중에서 a개를 선택해야 하고 이때의 커플 간 성격 차이의 합이 최소가 되어야 하므로 먼저 두 그룹을 정렬하였습니다.
- 이때 a와 b의 최댓값이 1000이기 때문에 완전 탐색으로는 답을 구할 수 없고 가장 가까운 값끼리 매칭하는 그리디 방식으로는 최적의 해를 보장할 수 없어 DP로 접근하였습니다.
- DP[i][j] : i명과 j명 중 일부를 매칭했을 때 얻을 수 있는 각 성격 차이의 합의 최솟값으로 정의 하였습니다.
- 이때 i는 인원 수가 더 작은 그룹, j는 더 큰 그룹으로 설정하였으며 j번째 사람이 커플에 포함되는 경우와 되지 않은 경우로 나누어 접근하였습니다.
	- j가 포함되지 않는 경우: DP[i][j-1]
	- j가 포함되는 경우: DP[i-1][j-1] + |a[i] - b[j]|
- 주의할 점은 j가 더 큰 인원 수 그룹의 값이기 때문에 항상 `i<=j`를 만족해야 합니다.

---

### 문제 5: Ignition

**문제 난이도**

- 플레티넘 5

**문제 유형**

- 

**접근 방식 및 풀이**

- 

---