### PR TITLE
[유병규-17주차 알고리즘 스터디]

### DIFF
--- a/유병규_17주차/[BOJ-11085] 군사 이동.java
+++ b/유병규_17주차/[BOJ-11085] 군사 이동.java
@@ -1,0 +1,68 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int p = Integer.parseInt(st.nextToken());
+        int w = Integer.parseInt(st.nextToken());
+        
+        st = new StringTokenizer(br.readLine());
+        int s = Integer.parseInt(st.nextToken());
+        int e = Integer.parseInt(st.nextToken());
+        
+        List<Edge>[] graph = new ArrayList[p];
+        for(int i=0; i<p; i++) {
+        	graph[i] = new ArrayList<>();
+        }
+        
+        for(int i=0; i<w; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	
+        	int a = Integer.parseInt(st.nextToken());
+        	int b = Integer.parseInt(st.nextToken());
+        	int c = Integer.parseInt(st.nextToken());
+        	
+        	graph[a].add(new Edge(b, c));
+        	graph[b].add(new Edge(a, c));
+        }
+        
+        PriorityQueue<int[]> pq = new PriorityQueue<>((o1, o2) -> -Integer.compare(o1[1], o2[1]));
+        boolean[] visited = new boolean[p];
+        pq.offer(new int[] {s, Integer.MAX_VALUE});
+        
+        while(!pq.isEmpty()) {
+        	int[] info = pq.poll();
+        	int current = info[0];
+        	
+        	if(current == e) {
+        		System.out.println(info[1]);
+        		return;
+        	}
+        	
+        	if(visited[current]) continue;
+        	visited[current] = true;
+        	
+        	for(Edge edge : graph[current]) {
+        		if(visited[edge.to]) continue;
+        		pq.offer(new int[] {edge.to, Math.min(info[1], edge.weight)});
+        	}
+        }
+        
+        System.out.println(0);
+    }
+    
+    public static class Edge{
+    	int to;
+    	int weight;
+    	
+    	public Edge(int to, int weight) {
+    		this.to = to;
+    		this.weight = weight;
+    	}
+    }
+}

--- a/유병규_17주차/[BOJ-15898] 피아의 아틀리에 -신비한 대회의 연금술사-.java
+++ b/유병규_17주차/[BOJ-15898] 피아의 아틀리에 -신비한 대회의 연금술사-.java
@@ -1,0 +1,176 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static final int ORDER_SIZE = 3;
+	private static final int MATTER_SIZE = 4;
+	private static final int KILN_SIZE = 5;
+	
+	private static int n;
+	private static Matter[][] matters;
+	private static int[][] order;
+	private static int result;
+	private static Matter kiln;
+    private static int[][] position = {{0,0},{0,1},{1,0},{1,1}};
+    private static boolean[] visited;
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        n = Integer.parseInt(br.readLine());
+        matters = new Matter[n][4];
+        for(int i=0; i<n; i++) {
+        	matters[i][0] = new Matter(MATTER_SIZE);
+        }
+        
+        //각 재료 초기화
+        for(int repeat=0; repeat<n; repeat++) {
+        	//재료
+        	Matter matter = matters[repeat][0];
+        	//효능 초기화
+        	for(int i=0; i<MATTER_SIZE; i++) {
+        		StringTokenizer st = new StringTokenizer(br.readLine());
+        		for(int j=0; j<MATTER_SIZE; j++) {
+        			matter.value[i][j] = Integer.parseInt(st.nextToken());
+        		}
+        	}
+        	//원소 초기화
+        	for(int i=0; i<MATTER_SIZE; i++) {
+        		StringTokenizer st = new StringTokenizer(br.readLine());
+        		for(int j=0; j<MATTER_SIZE; j++) {
+        			matter.element[i][j] = st.nextToken().charAt(0);
+        		}
+        	}
+        }
+        
+        //돌린거 저장
+        for(int i=0; i<n; i++) {
+        	for(int j=1; j<4; j++) {
+        		matters[i][j] = rotate(matters[i][j-1]);
+        	}
+        }
+        
+        //가마 초기화
+        kiln = new Matter(KILN_SIZE);
+        for(int i=0; i<KILN_SIZE; i++) {
+        	for(int j=0; j<KILN_SIZE; j++) {
+        		kiln.element[i][j] = 'W';
+        	}
+        }
+        
+        order = new int[ORDER_SIZE][3];
+        visited = new boolean[n];
+        result = 0;
+        dfs(0);
+        
+        System.out.println(result);
+    }
+    
+    private static Matter rotate(Matter matter) {
+    	Matter temp = new Matter(MATTER_SIZE);
+    	
+    	for(int i=0; i<MATTER_SIZE; i++) {
+    		for(int j=0; j<MATTER_SIZE; j++) {
+    			temp.value[i][j] = matter.value[MATTER_SIZE-1-j][i];
+    			temp.element[i][j] = matter.element[MATTER_SIZE-1-j][i];
+    		}
+    	}
+    	
+    	return temp;
+    }
+    
+    private static void dfs(int dept) {
+    	if(dept == ORDER_SIZE) {
+    		kiln.clear();
+    		for(int i=0; i<3; i++) {
+    			Matter matter = matters[order[i][0]][order[i][1]];
+    			putMatter(matter, position[order[i][2]][0], position[order[i][2]][1]);
+    		}
+    		
+    		int total = calcul();
+    		result = Math.max(result, total);
+    		return;
+    	}
+    	
+    	for(int i=0; i<n; i++) {
+    		if(visited[i]) continue;
+    		visited[i] = true;
+    		order[dept][0] = i;
+    		for(int repeat=0; repeat<4; repeat++) {
+    			order[dept][1] = repeat;
+    			for(int idx=0; idx<position.length; idx++) {
+    				order[dept][2] = idx;
+        			dfs(dept+1);
+        		}
+    		}
+    		visited[i] = false;
+    	}
+    }
+
+	private static void putMatter(Matter matter, int x, int y) {
+		for(int i=0; i<MATTER_SIZE; i++) {
+			for(int j=0; j<MATTER_SIZE; j++) {
+				int ni = i+x, nj = j+y;
+				//품질 변경
+				int value = kiln.value[ni][nj] + matter.value[i][j];
+				if(value < 0) value = 0;
+				if(value > 9) value = 9;
+				kiln.value[ni][nj] = value;
+				
+				//원소 변경
+				if(matter.element[i][j] == 'W') continue;
+				kiln.element[ni][nj] = matter.element[i][j];
+			}
+		}
+	}
+
+	private static int calcul() {
+		int r=0, b=0, g=0, y=0;
+		
+        for(int i=0; i<KILN_SIZE; i++) {
+        	for(int j=0; j<KILN_SIZE; j++) {
+        		int value = kiln.value[i][j];
+        		switch(kiln.element[i][j]) {
+        		case 'R': r += value; break;
+        		case 'B': b += value; break;
+        		case 'G': g += value; break;
+        		case 'Y': y += value; break;
+        		default: break;
+        		}
+        	}
+        }
+		
+		return 7*r + 5*b + 3*g + 2*y;
+	}
+
+	private static class Matter{
+    	int[][] value;
+    	char[][] element;
+    	
+    	public Matter(int size) {
+    		value = new int[size][size];
+    		element = new char[size][size];
+    	}
+
+    	public void clear() {
+    		for(int i=0; i<value.length; i++) {
+    			Arrays.fill(value[i], 0);
+    			Arrays.fill(element[i], 'W');
+    		}
+    	}
+		
+		@Override
+		public String toString() {
+			StringBuilder sb = new StringBuilder();
+			for(int i=0; i<value.length; i++) {
+				sb.append("[");
+				for(int j=0; j<value.length-1; j++) {
+					sb.append(value[i][j]+""+element[i][j]+", ");
+				}
+				sb.append(value[i][value.length-1]+""+element[i][value.length-1]+"");
+				sb.append("]\n");
+			}
+			return sb.toString().trim();
+		}
+    }
+}

--- a/유병규_17주차/[BOJ-17837] 새로운 게임 2.java
+++ b/유병규_17주차/[BOJ-17837] 새로운 게임 2.java
@@ -1,0 +1,195 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	private static int[][] d = {{0,1},{0,-1},{-1,0},{1,0}};
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        
+        Cell[][] board = new Cell[n][n];
+        for(int i=0; i<n; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	for(int j=0; j<n; j++) {
+        		board[i][j] = new Cell(Integer.parseInt(st.nextToken()));
+        	}
+        }
+
+        Piece[] pieces = new Piece[k];
+        for(int i=0; i<k; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	int x = Integer.parseInt(st.nextToken())-1;
+        	int y = Integer.parseInt(st.nextToken())-1;
+        	int d = Integer.parseInt(st.nextToken())-1;
+        	
+        	pieces[i] = new Piece((i+1), x, y, d);
+        	board[x][y].bottom = pieces[i];
+        }
+        
+        int count = 0;
+        while(count <= 1000) {
+        	count++;
+        	for(int i=0; i<k; i++) {
+        		Piece piece = pieces[i];
+        		
+        		int nx = piece.x + d[piece.dir][0];
+        		int ny = piece.y + d[piece.dir][1];
+        		//이동할 곳이 보드 밖이거나 파란색일 경우
+        		if(nx<0 || nx>=n || ny<0 || ny>=n || board[nx][ny].type == 2) {
+        			//방향전환하고
+        			piece.changeDir();
+        			//이동할 곳
+        			nx = piece.x + d[piece.dir][0];
+            		ny = piece.y + d[piece.dir][1];
+            		
+            		//이동할 곳이 다시 보드 밖이거나 파란색일 경우 이동하지 않음
+            		if(nx<0 || nx>=n || ny<0 || ny>=n || board[nx][ny].type == 2) continue;
+        		}
+        		//흰색이거나 빨간색인 경우 이동함        		
+        		//말 아래에 말이 있던 경우에는 연결 끊기
+        		if(piece.down != null) {
+        			piece.down.up = null;
+        			piece.down = null;
+        		}
+
+        		//움직이는 말이 보드에 직접 맞닿아 있는 말이라면 기존 칸 위에는 말이 없음
+        		if(board[piece.x][piece.y].bottom == piece)
+        			board[piece.x][piece.y].bottom = null;
+        		
+        		//말 이동
+        		piece.x = nx;
+        		piece.y = ny;
+        		piece.update();
+        		
+        		//빨간색이고 말 위에 말이 있다면
+        		if(board[nx][ny].type == 1 && piece.up != null) {
+        			//뒤집음
+        			Piece bottom = piece;
+        			while(piece != null) {
+        				Piece temp = piece.up;
+        				piece.up = piece.down;
+        				piece.down = temp;
+        				bottom = piece;
+        				piece = temp;
+        			}
+        			
+        			piece = bottom;
+        		}
+        		
+        		//해당 칸에 말이 없을 경우
+        		if(board[nx][ny].bottom == null) {
+        			board[nx][ny].bottom = piece;
+        		}
+        		
+        		//해당 칸에 말이 있을 경우
+        		else {
+        			Piece top = board[nx][ny].bottom.getTop();
+        			piece.down = top;
+        			top.up = piece;
+        		}
+        		
+        		//개수 체크
+        		if(board[nx][ny].bottom.size() >= 4) {
+        			System.out.println(count);
+        			return;
+        		}
+        	}
+        }
+        
+        System.out.println(-1);
+    }
+    
+    private static class Cell{
+    	int type;
+    	Piece bottom;
+    	
+    	public Cell(int type) {
+    		this.type = type;
+    	}
+    	
+    	@Override
+    	public String toString() {
+    		String sType = "W";
+    		if(type == 1) sType = "R";
+    		else if(type == 2) sType = "B";
+    		
+    		String sbottom = bottom == null ? "x" : bottom.toString();
+    		
+    		return "["+sType+"/"+sbottom+"]";
+    	}
+    }
+    
+    private static class Piece{
+    	int num;
+    	int x, y;
+    	int dir;
+    	Piece up, down;
+    	
+    	public Piece(int num, int x, int y, int dir) {
+    		this.num = num;
+    		this.x = x;
+    		this.y = y;
+    		this.dir = dir;
+    	}
+
+		public int size() {
+			Piece next = this;
+			int count = 1;
+			while(next.up != null) {
+				next = next.up;
+				count++;
+			}
+			return count;
+		}
+
+		public Main.Piece getTop() {
+			Piece next = this;
+			while(next.up != null) {
+				next = next.up;
+			}
+			return next;
+		}
+
+		public void update() {
+			Piece next = this.up;
+			while(next != null) {
+				next.x = this.x;
+				next.y = this.y;
+				next = next.up;
+			}
+		}
+
+		public void changeDir() {
+			switch(dir) {
+			case 0: dir = 1; break;
+			case 1: dir = 0; break;
+			case 2: dir = 3; break;
+			case 3: dir = 2; break;
+			}
+		}
+		
+		public String getSDir() {
+			String sdir = "→";
+    		if(dir == 1) sdir = "←";
+    		else if(dir == 2) sdir = "↑";
+    		else if(dir == 3) sdir = "↓";
+    		return sdir;
+		}
+		
+    	@Override
+    	public String toString() {
+    		String snum = num+"("+getSDir()+")";
+    		Piece next = this.up;
+    		while(next != null) {
+    			snum += ","+next.num+"("+next.getSDir()+")";
+    			next = next.up;
+    		}
+    		return snum;
+    	}
+    }
+}

--- a/유병규_17주차/[BOJ-8980] 택배.java
+++ b/유병규_17주차/[BOJ-8980] 택배.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+	
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        
+        int n = Integer.parseInt(st.nextToken());
+        int c = Integer.parseInt(st.nextToken());
+        
+        List<int[]> order = new ArrayList<>();
+        
+        int m = Integer.parseInt(br.readLine());
+        for(int i=0; i<m; i++) {
+        	st = new StringTokenizer(br.readLine());
+        	int a = Integer.parseInt(st.nextToken());
+        	int b = Integer.parseInt(st.nextToken());
+        	int d = Integer.parseInt(st.nextToken());
+        	
+        	order.add(new int[] {a, b, d});
+        }
+        //도착지 기준 정렬
+        Collections.sort(order, (o1, o2) -> Integer.compare(o1[1], o2[1]));
+        
+        //트럭에 실은 박스들
+        int[] village = new int[n+1];
+        
+        //트럭 출발
+        int result = 0;
+        for(int idx=0; idx<m; idx++) {
+        	int[] info = order.get(idx);
+        	
+        	int start = info[0];
+        	int end = info[1];
+        	int amount = info[2];
+        	
+        	int maxLoad = 0;
+        	for(int i=start; i<end; i++) {
+        		maxLoad = Math.max(village[i], maxLoad);
+        	}
+        	
+        	int canLoad = Math.min(amount, c-maxLoad);
+        	
+        	result += canLoad;
+        	for(int i=start; i<end; i++) {
+        		village[i] += canLoad;
+        	}
+        }
+        
+        System.out.println(result);
+    }
+}


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 17주차 [유병규]

## 📌 문제 풀이 개요

- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.

---

## ✅ 문제 해결 여부

- [x]  **피아의 아틀리에 \~신비한 대회의 연금술사\~**
- [x]  **새로운 게임 2**
- [x]  **군사 이동**
- [ ]  **인하니카 공화국**
- [x]  **택배**

---

## 💡 풀이 방법

### 문제 1: 피아의 아틀리에 \~신비한 대회의 연금술사\~

**문제 난이도**

- 골드 1

**문제 유형**

- 구현, 브루트포스, 시뮬레이션

**접근 방식 및 풀이**

- 문제를 정리하면 다음과 같습니다.
```
 재료(4x4)
 	- 효능: -9~9
 	- 원소: R/B/G/Y/W
 
 가마(5x5)
 	- 품질: 초기 0 -(재료)-> 품질+효능(0~9)
 	- 원소: 초기 W -(재료)-> 재료원소:W => 그대로 / 그 외 재료 원소 색으로.
 
 재료 3개 고른 뒤 순서를 정해 하나씩 가마에 넣음(90도씩 회전가능).
 
 빨강, 파랑, 초록, 노랑으로 칠해진 부분의 품질 합을 각각 R, B, G, Y
 폭탄의 품질 = 7R + 5B + 3G + 2Y
 
 폭탄의 최대 품질 값
 ```
- 주어진 재료를 순서를 고려하여 $N$개 중에 3개를 선택한 후 가마에 넣는 문제입니다.
- 이때 재료를 90도 회전할 수 있고, 재료의 왼쪽 상단을 가마의 `[0,0]`,`[1,0]`,`[0,1]`,`[1,1]` 중 한 곳에 넣을 수 있습니다.
- $n<=10$, 재료 선택이 3개이기 때문에 DFS로 구현하였습니다. 처음에는 재료를 하나 선택하여 회전하고 가마에 더한 뒤 다음 재료를 선택하도록 구현하였는데, 시간초과가 났습니다. 이 방법을 사용하면 백트래킹을 위해 가마를 이전 상태로 되돌려놔야 되기 때문에 `copy()`가 필요했고 이 과정에서 연산이 많이 수행되었습니다.
- 최적화를 위해 재료를 선택한 뒤 매번 재료를 돌려보는 것이 아니라 미리 재료를 돌려놓은 상태를 저장해놓아 계산 수를 줄였습니다. 또한 재료를 하나 선택할 때마다 가마에 더하는 것이 아닌, 재료의 순서와 상태, 가마에 넣는 위치를 미리 정해놓은 후, 한 번에 가마에 더하는 방식으로 수정하여 문제를 해결할 수 있었습니다. 위 방법을 사용 시 가마를 `copy()`할 필요가 없어져 시간을 줄일 수 있습니다.

---

### 문제 2: 새로운 게임 2

**문제 난이도**

- 골드 2

**문제 유형**

- 구현, 시뮬레이션

**접근 방식 및 풀이**

- 말이 이동할 때 말 위에 또다른 말이 있을 경우 같이 이동해야 하고, 말로 만들어진 탑에서 중간 위치의 말이 이동할 경우 해당 말 위에 있는 말들만 같이 이동하는 등등, 말과 말이 연결되고 끊어지는 연산이 자주 나오고, 말이 4개 이상 모이면 게임이 끝나므로 `LinkedList` 형식으로 구현하였습니다.
- 말의 정보를 저장하는 `Piece` 클래스를 생성하였고 아래 필드를 가집니다.
	- `x`, `y`: 말의 x좌표와 y좌표
	- `dir`: 말의 방향
	- `up`: 바로 위에 있는 말
	- `down`: 바로 아래에 있는 말
- 보드에서 각 칸에는 어떤 말이 존재하는 지 알아야 하기에 `Cell` 클래스를 생성하였고 아래 필드를 가집니다.
	- `type`: 칸의 타입(흰색, 빨간색, 파란색)
	- `bottom`: 해당 칸과 직접 닿아있는 말
- 두 클래스를 사용하여 직접 말을 움직이며 해결할 수 있었습니다.

---

### 문제 3: 군사 이동

**문제 난이도**

- 골드 3

**문제 유형**

- 자료구조, 분리 집합

**접근 방식 및 풀이**

- 시작 정점에서 도착 정점까지 가는 길 중에서 가중치가 가장 작은 값이 최대가 되도록 하는 길을 찾는 문제입니다.
- 이전에 풀었던 세부 문제와 동일한 문제라 생각되어 MST를 사용하여 문제를 해결하였습니다.
- 힙의 정렬 조건을 '이제까지의 경로 중 최소 가중치'의 값이 더 큰 값이 선행되도록 수정하였고, 도착 정점에 왔을 시 저장했던 값이 정답이기 때문에 출력하고 종료하였습니다.

---

### 문제 4: 인하니카 공화국

**문제 난이도**

- 골드 3

**문제 유형**

- 

**접근 방식 및 풀이**

- 

---

### 문제 5: 택배

**문제 난이도**

- 골드 1

**문제 유형**

- 그리디, 정렬

**접근 방식 및 풀이**

- 트럭은 다시 뒤로 돌아오지 않고, 최대한 많은 택배를 배달해야하므로 택배가 트럭에 적재되어 있는 시간이 가장 짧아야 합니다.
- 그래서 입력 값(배송 정보)을 도착지 기준으로 오름차순 정렬을 하여 택배를 빨리 내리도록 설정하였습니다.
- 이때 도착지 기준으로 정렬하였기 때문에 이 택배를 언제 실을 수 있고 얼만큼 실을 수 있는 지를 계산해야 합니다. 이를 마을을 지나면서 매번 적제하는 시뮬레이션 방식 대신 해당 택배를 배송할 시점의 상황을 계산하였습니다.
- 먼저 각 마을을 지날 시점의 적재량을 계산하는 배열(`village`)을 생성한 후 정렬한 배송 정보를 순회하며 다음 작업을 진행합니다.
	1. 해당 택배의 출발지부터 도착지 바로 전까지 마을들 중 적재량이 가장 많은 값(`maxLoad`)을 가져옵니다.
	2. '트럭 용량`maxLoad`'와 '해당 택배의 개수' 중 더 작은 값이 트럭에 적재할 수 있는 값이고, 이는 곧 배달할 수 있는 값이므로 결과 값(`result`)에 더해줍니다.
	3. 이 택배는 출발지와 도착지 바로 전까지 마을을 지나면서 가지고 다녀야 하는 택배이기 때문에 출발지부터 도착지 바로 전까지 마을 각각에 적재량을 더해줍니다.(`village`배열)
	4. 모든 배송 정보에 대해 1\~3번을 반복합니다.

---