### PR TITLE
Khj20006/week 17

### DIFF
--- a/권혁준_17주차/[BOJ-11085] 군사 이동.md
+++ b/권혁준_17주차/[BOJ-11085] 군사 이동.md
@@ -1,0 +1,69 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M, S, E;
+	static int[][] G;
+	static int[] r;
+	
+	static int f(int x) {return x==r[x] ? x : (r[x]=f(r[x]));}
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		S = nextInt();
+		E = nextInt();
+		r = new int[N];
+		for(int i=0;i<N;i++) r[i] = i;
+		G = new int[M][];
+		for(int i=0;i<M;i++) G[i] = new int[] {nextInt(), nextInt(), nextInt()};
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		Arrays.sort(G, (a,b) -> b[2]-a[2]);
+		for(int[] e:G) {
+			int a = e[0], b = e[1], c = e[2];
+			int x = f(a), y = f(b);
+			if(x == y) continue;
+			r[x] = y;
+			if(f(S) == f(E)) {
+				bw.write(c + "\n");
+				return;
+			}
+		}
+		
+	}
+	
+}
+```

--- a/권혁준_17주차/[BOJ-12784] 인하니카 공화국.md
+++ b/권혁준_17주차/[BOJ-12784] 인하니카 공화국.md
@@ -1,0 +1,66 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static int N, M;
+	static List<int[]>[] V;
+	
+	public static void main(String[] args) throws Exception {
+		
+		for(int T=nextInt();T-->0;solve()) ready();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		M = nextInt();
+		V = new List[N+1];
+		for(int i=1;i<=N;i++) V[i] = new ArrayList<>();
+		for(int i=1;i<N;i++) {
+			int a = nextInt(), b = nextInt(), c = nextInt();
+			V[a].add(new int[] {b,c});
+			V[b].add(new int[] {a,c});
+		}
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		bw.write((N == 1 ? 0 : dfs(1,0)) + "\n");
+		
+	}
+	
+	static int dfs(int n, int p) {
+		int res = 0, child = 0;
+		for(int[] e:V[n]) if(e[0] != p) {
+			int i = e[0], c = e[1];
+			res += Math.min(dfs(i,n), c);
+			child++;
+		}
+		return child>0 ? res : (int)1e7;
+	}
+	
+}
+```

--- a/권혁준_17주차/[BOJ-1701] Cubeditor.md
+++ b/권혁준_17주차/[BOJ-1701] Cubeditor.md
@@ -1,0 +1,61 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static char[] B;
+	static int[] X;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		B = br.readLine().toCharArray();
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		int max = 0;
+		for(int l=0;l<B.length-1;l++) {
+			char[] A = new char[B.length-l];
+			for(int i=0;i<A.length;i++) A[i] = B[i+l];
+			X = new int[A.length];
+			for(int i=1;i<A.length;i++) {
+				X[i] = X[i-1];
+				while(X[i]>0 && A[X[i]] != A[i]) X[i] = X[X[i]-1];
+				if(A[X[i]] == A[i]) X[i]++;
+				max = Math.max(X[i], max);
+			}			
+		}
+		bw.write(max + "\n");
+		
+	}
+	
+}
+```

--- a/권혁준_17주차/[BOJ-2842] 집배원 한상덕.md
+++ b/권혁준_17주차/[BOJ-2842] 집배원 한상덕.md
@@ -1,0 +1,105 @@
+```java
+import java.util.*;
+import java.io.*;
+
+public class Main {
+	
+	// IO field
+	static BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+	static BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+	static StringTokenizer st = new StringTokenizer("");
+
+	static void nextLine() throws Exception {st = new StringTokenizer(br.readLine());}
+	static String nextToken() throws Exception {
+		while(!st.hasMoreTokens()) nextLine();
+		return st.nextToken();
+	}
+	static int nextInt() throws Exception { return Integer.parseInt(nextToken()); }
+	static long nextLong() throws Exception { return Long.parseLong(nextToken()); }
+	static double nextDouble() throws Exception { return Double.parseDouble(nextToken()); }
+	static void bwEnd() throws Exception {bw.flush();bw.close();}
+	
+	// Additional field
+	
+	static final int[] dx = {-1,-1,-1,0,0,1,1,1};
+	static final int[] dy = {-1,0,1,-1,1,-1,0,1};
+	
+	static int N;
+	static char[][] A;
+	static int[][] H;
+	static int[] L;
+	static int sx, sy, cnt = 0;
+	
+	public static void main(String[] args) throws Exception {
+		
+		ready();
+		solve();
+		
+		bwEnd();
+		
+	}
+	
+	static void ready() throws Exception{
+		
+		N = nextInt();
+		A = new char[N][];
+		H = new int[N][N];
+		L = new int[N*N];
+		for(int i=0;i<N;i++) {
+			A[i] = br.readLine().toCharArray();
+			for(int j=0;j<N;j++) {
+				if(A[i][j] == 'P') {
+					sx = i;
+					sy = j;
+				}
+				if(A[i][j] == 'K') cnt++;
+			}
+		}
+		for(int i=0;i<N;i++) for(int j=0;j<N;j++) L[i*N+j] = H[i][j] = nextInt();
+		
+	}
+	
+	static void solve() throws Exception {
+		
+		Arrays.sort(L);
+		int ans = Integer.MAX_VALUE;
+		for(int min:L) if(min <= H[sx][sy]) {
+			int s = min, e = L[N*N-1]+1, m = (s+e)>>1;
+			while(s<e) {
+				if(bfs(min,m)) e = m;
+				else s = m+1;
+				m = (s+e)>>1;
+			}
+			if(m == L[N*N-1]+1) continue;
+			ans = Math.min(m-min, ans);
+		}
+		bw.write(ans + "\n");
+		
+	}
+	
+	static boolean bfs(int l, int r) {
+		int fd = 0;
+		if(H[sx][sy] < l || H[sx][sy] > r) return false;
+		Queue<int[]> Q = new LinkedList<>();
+		Q.offer(new int[] {sx,sy});
+		boolean[][] vis = new boolean[N][N];
+		vis[sx][sy] = true;
+		while(!Q.isEmpty()) {
+			int[] now = Q.poll();
+			int x = now[0], y = now[1];
+			if(A[x][y] == 'K') {
+				fd++;
+				if(fd == cnt) return true;
+			}
+			for(int i=0;i<8;i++) {
+				int xx = x+dx[i], yy = y+dy[i];
+				if(xx<0 || xx>=N || yy<0 || yy>=N || H[xx][yy] < l || H[xx][yy] > r || vis[xx][yy]) continue;
+				vis[xx][yy] = true;
+				Q.offer(new int[] {xx,yy});
+			}
+		}
+		return false;
+	}
+	
+}
+```


### PR DESCRIPTION
# 🚀 싸피 15반 알고리즘 스터디 17주차 [권혁준]

## 📌 문제 풀이 개요
- 이번 PR에서는 다음 5문제의 풀이를 포함합니다.
- 각 문제에 대한 풀이 과정과 접근 방식을 설명합니다.
---

## ✅ 문제 해결 여부

  - [ ] **피아의 아틀리에 ~신비한 대회의 연금술사~**
  - [ ] **새로운 게임 2**  
  - [x] **군사 이동**
  - [x] **인하니카 공화국**  
  - [ ] **택배**  
  
---
  
  - [x] **집배원 한상덕**
  - [ ] **어항 정리**
  - [x] **Cubeditor**

---

## 💡 풀이 방법
### 문제 1: 피아의 아틀리에 ~신비한 대회의 연금술사~

**문제 난이도**



**문제 유형**



**접근 방식 및 풀이**



---


### 문제 2: 새로운 게임 2

**문제 난이도**



**문제 유형**



**접근 방식 및 풀이**



---


### 문제 3: 군사 이동

**문제 난이도**

Gold 3

**문제 유형**

- 분리 집합

**접근 방식 및 풀이**

많은 풀이들이 떠올랐다.

정답을 매개 변수로 놓고 이분 탐색도 가능하고, 이를 성능 개선시키면 결국 가중치가 큰 순서대로 크루스칼 알고리즘을 돌리는 풀이가 나옵니다.
저번 주에 풀었던 세부 문제랑 거의 같습니다.

---


### 문제 4: 인하니카 공화국

**문제 난이도**

Gold 3

**문제 유형**

- 트리
- DFS

**접근 방식 및 풀이**

문제 지문에 `두 섬을 연결하는 다리를 최소한의 개수로 만들어 모든 섬 간의 왕래가 가능하도록 만들었다.`
이런 말이 있습니다.
즉, 그래프는 트리 형태로만 주어진다는 의미이고, 리프에서부터 루트까지 올라오는 길목이 존재하지 않도록 적절히 차단해야 하는 문제로 바꿔서 생각했습니다.

`D[n] = n을 루트로 하는 서브트리까지 오지 못하도록 막는 최소 비용`으로 정의하면,
비용이 v인 간선 (n,c)에 대해 min(D[c], v)의 합이 D[n]이 됩니다.

DFS로 위 값을 리프에서부터 구해주면, D[1]이 문제의 정답이 됩니다.

---


### 문제 5: 택배

**문제 난이도**



**문제 유형**



**접근 방식 및 풀이**


---


### 문제 6: 집배원 한상덕

**문제 난이도**

Platinum 4

**문제 유형**

- 그래프 탐색
- 이분 탐색 (+ 매개 변수 탐색)

**접근 방식 및 풀이**

고도의 범위가 크지만, 고도의 종류는 최대 N^2 뿐입니다.

이동 가능한 고도의 범위 [L, R]을 제한한다면, 가능/불가능을 판별하는 **결정 문제**로 변합니다.

L을 완탐 돌리고 R을 이분 탐색으로 찾아서 문제를 해결했습니다.
(=> 같은 논리를 가지고, 이분 탐색 대신 투 포인터로 푸는 풀이가 더 빠르고 깔끔한 것 같아요)

---


### 문제 7: 어항 정리

**문제 난이도**



**문제 유형**



**접근 방식 및 풀이**


---


### 문제 8: Cubeditor

**문제 난이도**

Gold 2

**문제 유형**

- KMP

**접근 방식 및 풀이**

처음엔 단순 투 포인터로 알고 풀었다가 틀렸습니다.

이후, KMP의 실패 함수(부분 일치 테이블)을 사용했습니다.
부분 일치 테이블의 최댓값이 곧 문제의 정답이 됨을 이용해서 풀었습니다.

A의 모든 접미사에 대해서 이를 수행해주고, 그 중 최댓값을 뽑아 출력했습니다.

---

